### PR TITLE
Minor update to colophon for 1CO

### DIFF
--- a/USFM/47_1CO_RV1865.usfm
+++ b/USFM/47_1CO_RV1865.usfm
@@ -1,6 +1,6 @@
 \id 1CO Spanish Reina Valera Translation 1865 Revision
 \ide UTF-8
-\rem Updated 2018-12-04
+\rem Updated 2018-12-10
 \toc1 La Primera Epístola Del Apóstol San Pablo A Los Corintios
 \toc2 1 Corintios
 \toc3 1 Cor
@@ -459,4 +459,4 @@
 \v 22 Si alguno no amare al Señor Jesu Cristo sea Anatema Maranatha.
 \v 23 La gracia de nuestro Señor Jesu Cristo \add sea\add* con vosotros.
 \v 24 Mi amor en Cristo Jesús \add sea\add* con todos vosotros. Amén.
-\p ¶ La primera \add epístola a\add* los Corintios fue escrita de Filipos por Estéfanas, y Fortunato, y Acaico, y Timoteo.
+\p ¶ La primera \add epístola\add* a los Corintios fue escrita de Filipos por Estéfanas, y Fortunato, y Acaico, y Timoteo.


### PR DESCRIPTION
Moved ` a` to after `add*`.

> I’m sure that the inclusion of the “a” is accidental, since the Greek article is accusative, and the personal “a” in Spanish is an explicit indicator of the indirect object if it’s a person or something that is personified. It can be moved outside of the \add* 

Vince LaRue 