### PR TITLE
Made various pending changes, fixed "Él" missing accent in all files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# macOS generated files #
+#########################
+
+.DS_Store

--- a/USFM/01_GEN_RV1865.usfm
+++ b/USFM/01_GEN_RV1865.usfm
@@ -97,7 +97,7 @@
 \v 5 Y a Caín y a su presente no miró. Y ensañóse Caín en gran manera, y decayó su semblante.
 \v 6 ¶ Entonces Jehová dijo a Caín: ¿Por qué te has ensañado? ¿y por qué ha decaído tu semblante?
 \v 7 ¿Cómo, no serás ensalzado si bien hicieres: y si no hicieres bien, no estarás echado \add por tu\add* pecado a la puerta? Con todo esto, a ti será su deseo; y tú te enseñorearás de él.
-\v 8 Y hablo Caín a su hermano Abel. Y aconteció que estando ellos en el campo, Caín se levantó contra Abel su hermano, y le mató.
+\v 8 Y habló Caín a su hermano Abel. Y aconteció que estando ellos en el campo, Caín se levantó contra Abel su hermano, y le mató.
 \v 9 ¶ Y Jehová dijo a Caín: ¿Dónde \add está\add* Abel tu hermano? Y él respondió: No sé: ¿Soy yo guarda de mi hermano?
 \v 10 Y él le dijo: ¿Qué has hecho? La voz de la sangre de tu hermano clama a mí desde la tierra.
 \v 11 Ahora, pues, maldito \add seas\add* tú de la tierra, que abrió su boca para recibir la sangre de tu hermano de tu mano.
@@ -526,7 +526,7 @@
 \v 2 Y decía Abraham de Sara su mujer: Mi hermana es. Y Abimelec, rey de Gerar, envió, y tomó a Sara.
 \v 3 Empero Dios vino a Abimelec en sueños de noche, y díjole: He aquí, muerto eres por la mujer que tomaste, la cual es casada con marido.
 \v 4 Mas Abimelec no había llegado a ella, y dijo: Señor: ¿matarás también la gente justa?
-\v 5 ¿El no me dijo: Mi hermana es; y ella también dijo: Mi hermano es? Con sencillez de mi corazón, y con limpieza de mis manos he hecho esto.
+\v 5 ¿Él no me dijo: Mi hermana es; y ella también dijo: Mi hermano es? Con sencillez de mi corazón, y con limpieza de mis manos he hecho esto.
 \v 6 Y díjole Dios en sueños: Yo también sé que con entereza de tu corazón has hecho esto: y yo también te detuve de pecar contra mí, por tanto no te permití que tocases en ella.
 \v 7 Ahora, pues, vuelve la mujer a su marido, porque es profeta; y orará por ti, y vive. Y si tú no la volvieres, sepas que muriendo morirás con todo lo que fuere tuyo.
 \v 8 Entonces Abimelec se levantó de mañana, y llamó a todos sus siervos, y dijo todas estas palabras en los oídos de ellos, y temieron los hombres en gran manera.
@@ -1180,7 +1180,7 @@
 \v 14 Entonces ella quitó de sobre sí los vestidos de su viudez, y cubrióse con \add un\add* velo; y arrebozóse, y púsose a la puerta de las aguas que \add están\add* junto al camino de Tamnas; porque veía que había crecido Sela, y ella no era dada a él por mujer.
 \v 15 Y vióla Judá, y túvola por ramera; porque ella había cubierto su rostro.
 \v 16 Y apartóse del camino hacia ella, y díjola: Ea pues, ahora \add yo\add* entraré a ti: Porque no sabía que era su nuera. Y ella dijo: ¿Qué me has de dar, si entrares a mí?
-\v 17 El respondió: Yo te enviaré de las ovejas un cabrito de las cabras. Y ella dijo: Hásme de dar prenda hasta que lo envíes.
+\v 17 Él respondió: Yo te enviaré de las ovejas un cabrito de las cabras. Y ella dijo: Hásme de dar prenda hasta que lo envíes.
 \v 18 Entonces él dijo: ¿Qué prenda te daré? Ella respondió: Tu anillo, y tu manto, y tu bordón que \add tienes\add* en tu mano. Y él se lo dió; y entró a ella, la cual concibió de él.
 \v 19 Y levantóse y fuése: y quitóse el velo de sobre sí, y vistióse las ropas de su viudez.
 \v 20 Y Judá envió el cabrito de las cabras por mano de su amigo el Odollamita, para que tomase la prenda de mano de la mujer: y no la halló.
@@ -1521,7 +1521,7 @@
 \v 13 Y tomólos José a ambos, Efraím a su diestra, a la siniestra de Israel; y a Manasés a su siniestra, a la diestra de Israel, e hízolos llegar a él.
 \v 14 Entonces Israel extendió su diestra, y púsola sobre la cabeza de Efraím, que era el menor, y su siniestra sobre la cabeza de Manasés haciendo entender a sus manos, aunque Manasés era el primogénito.
 \v 15 Y bendijo a José, y dijo: El Dios en cuya presencia anduvieron mis padres Abraham e Isaac: el Dios que me mantiene desde que yo soy hasta este día,
-\v 16 El Ángel que me escapa de todo mal, bendiga a estos mozos: y mi nombre sea llamado en ellos, y el nombre de mis padres Abraham e Isaac, y multipliquen en multitud en medio de la tierra.
+\v 16 El ángel que me escapa de todo mal, bendiga a estos mozos: y mi nombre sea llamado en ellos, y el nombre de mis padres Abraham e Isaac, y multipliquen en multitud en medio de la tierra.
 \v 17 Entonces viendo José que su padre ponía la mano derecha sobre la cabeza de Efraím, pesóle en sus ojos; y tomó la mano de su padre, por quitarla de sobre la cabeza de Efraím a la cabeza de Manasés.
 \v 18 Y dijo José a su padre: No así, padre mío, porque este \add es\add* el primogénito: pon tu diestra sobre su cabeza.
 \v 19 Mas su padre no quiso, y dijo: \add Yo\add* lo sé, hijo mío, \add yo\add* lo sé: también él será en pueblo, y él también crecerá: mas su hermano menor será más grande que él, y su simiente será plenitud de gentes.

--- a/USFM/02_EXO_RV1865.usfm
+++ b/USFM/02_EXO_RV1865.usfm
@@ -244,7 +244,7 @@
 \v 17 Tú aun te ensalzas contra mi pueblo para no dejarlos ir.
 \v 18 \add Pues\add* he aquí que mañana a estas horas yo haré llover granizo muy grave, cual nunca fue en Egipto, desde el día que se fundó hasta ahora.
 \v 19 Envía pues, recoge tu ganado, y todo lo que tienes en el campo; porque todo hombre o animal que se hallare en el campo y no fuere recogido a casa, el granizo descenderá sobre él, y morirá.
-\v 20 El de los siervos de Faraón, que temió la palabra de Jehová, hizo huir sus siervos y su ganado a casa:
+\v 20 Él de los siervos de Faraón, que temió la palabra de Jehová, hizo huir sus siervos y su ganado a casa:
 \v 21 Mas el que no puso en su corazón la palabra de Jehová, dejó sus siervos y sus ganados en el campo.
 \v 22 Y Jehová dijo a Moisés: Extiende tu mano hacia el cielo, para que venga granizo en toda la tierra de Egipto sobre los hombres y sobre las bestias, y sobre toda la yerba del campo en la tierra de Egipto.
 \v 23 Y Moisés extendió su vara hacia el cielo, y Jehová hizo truenos, y fuego discurría por la tierra: y llovió Jehová granizo sobre la tierra de Egipto.
@@ -463,7 +463,7 @@
 \v 24 Y \add ellos\add* lo guardaron hasta la mañana, de la manera que Moisés había mandado, y no se pudrió, ni hubo en él gusano.
 \v 25 Y dijo Moisés: Comédlo hoy, porque hoy \add es\add* sábado de Jehová: hoy no lo hallaréis en el campo.
 \v 26 En los seis días lo cogeréis; y el séptimo día es sábado, en el cual no se hallará.
-\v 27 Y aconteció que \add algunos\add* del pueblosalieron en el séptimo día a coger, y no hallaron.
+\v 27 Y aconteció que \add algunos\add* del pueblo salieron en el séptimo día a coger, y no hallaron.
 \v 28 Y Jehová dijo a Moisés; ¿Hasta cuando no queréis guardar mis mandamientos, y mis leyes?
 \v 29 Mirád que Jehová os dio el sábado, y por eso os da en el sexto día pan para dos días. Estése pues cada uno en su estancia, y nadie salga de su lugar en el séptimo día.
 \v 30 Así el pueblo reposó el séptimo día.
@@ -1206,7 +1206,7 @@
 \v 27 E hicieron las túnicas de lino fino de obra de tejedor para Aarón, y para sus hijos.
 \v 28 Asimismo la mitra de lino fino, y las orladuras de los chapeos de lino fino, y los pañetes de lino, de lino torcido.
 \v 29 Ítem, el cinto de lino torcido, y de cárdeno, y púrpura, y carmesí, de obra de recamador, como Jehová lo mandó a Moisés.
-\v 30 Ítem, hicieron la plancha, la corona de la santidad, de oro puro, y escribieron en ella de grabadura de sello el rotulo, \sc Santidad a\sc* \nd Jehová\nd*.
+\v 30 Ítem, hicieron la plancha, la corona de la santidad, de oro puro, y escribieron en ella de grabadura de sello el rotulo, \sc Santidad a Jehová\sc*.
 \v 31 Y pusieron sobre ella un cordón de cárdeno para ponerla sobre la mitra encima, como Jehová lo había mandado a Moisés.
 \v 32 ¶ Y fue acabada toda la obra del tabernáculo, del tabernáculo del testimonio. E hicieron los hijos de Israel como Jehová lo había mandado a Moisés: así lo hicieron.
 \v 33 Y trajeron el tabernáculo a Moisés; el tabernáculo y todos sus vasos, sus corchetes, sus tablas, sus barras, y sus columnas y sus basas,

--- a/USFM/03_LEV_RV1865.usfm
+++ b/USFM/03_LEV_RV1865.usfm
@@ -577,7 +577,7 @@
 \v 14 No maldigas al sordo, y delante del ciego no pongas tropezón, mas habrás temor de tu Dios: Yo Jehová.
 \v 15 No harás injusticia en el juicio: no tendrás respeto al pobre, ni honrarás la faz del grande: con justicia juzgarás a tu prójimo.
 \v 16 No andarás chismeando en tus pueblos. No te pondrás contra la sangre de tu prójimo: Yo Jehová.
-\v 17 No aborrecerás a tu hermano en tu corazón: reprendiendo reprenderás a tu prójimo, y no consentirás sobre el pecado.
+\v 17 No aborrecerás a tu hermano en tu corazón: reprendiendo reprenderás a tu prójimo, y no consentirás sobre él pecado.
 \v 18 No te vengarás, ni guardarás \add la injuria\add* a los hijos de tu pueblo; mas amarás a tu prójimo, como a ti mismo: Yo Jehová.
 \v 19 Mis estatutos guardaréis. A tu animal no harás ayuntar para misturas. Tu haza no sembrarás de misturas: y vestido de misturas de diversas cosas, no subirá sobre ti.
 \v 20 Ítem, el varón cuando se juntare con mujer de ayuntamiento de simiente, y ella fuere sierva desposada a alguno, y no fuere rescatada, ni le hubiere sido dada libertad, serán azotados: no morirán: por cuanto \add ella\add* no es libre.

--- a/USFM/05_DEU_RV1865.usfm
+++ b/USFM/05_DEU_RV1865.usfm
@@ -61,7 +61,7 @@
 \v 5 No os revolváis con ellos, que no os daré de su tierra ni aun una holladura de una planta de un pie: porque \add yo\add* he dado por heredad a Esaú el monte de Seir.
 \v 6 La comida compraréis de ellos por dinero, y comeréis; y el agua también compraréis de ellos por dinero, y beberéis,
 \v 7 Pues que Jehová tu Dios te ha bendicho en toda obra de tus manos; \add él\add* sabe que andas por este gran desierto: estos cuarenta años Jehová tu Dios \add fue\add* contigo, y ninguna cosa te ha faltado.
-\v 8 Y pasámos de nuestros hermanos los hijos de Esaú, que habitaban en Seir, por el camino de la campaña de Elat, y de Asión-Gaber: y volvimos, y pasámos camino del desierto de Moab.
+\v 8 Y pasamos de nuestros hermanos los hijos de Esaú, que habitaban en Seir, por el camino de la campaña de Elat, y de Asión-Gaber: y volvimos, y pasámos camino del desierto de Moab.
 \v 9 Y Jehová me dijo: No molestes a Moab, ni te revuelvas con ellos en guerra, que no te daré posesión de su tierra; porque \add yo\add* he dado a Ar por heredad a los hijos de Lot.
 \v 10 Los Emimeos habitaron en ella antes, pueblo grande, y mucho, y alto como gigantes;
 \v 11 Por gigantes eran también contados ellos como los Enaceos, y los Moabitas los llamaban Emimeos.
@@ -215,7 +215,7 @@
 \v 7 Y repetirlas has a tus hijos, y hablarás de ellas estando en tu casa, y andando por el camino, y acostándote en la cama, y levantándote:
 \v 8 Y atarlas has por señal en tu mano, y estarán por frontales entre tus ojos.
 \v 9 Y escribirlas has en los postes de tu casa, y en tus portadas.
-\v 10 ¶ Y será, \add que\add* cuando Jehová tu Dios te hubiere metido en la tierra, que juró a tus padres Abraham, Isaac, y Jacob, para dartela a ti, ciudades grandes y buenas, que \add tú\add* no edificaste;
+\v 10 ¶ Y será, \add que\add* cuando Jehová tu Dios te hubiere metido en la tierra, que juró a tus padres Abraham, Isaac, y Jacob, para dártela a ti, ciudades grandes y buenas, que \add tú\add* no edificaste;
 \v 11 Y casas llenas de todo bien, que \add tú\add* no henchiste, y cisternas cavadas, que \add tú\add* no cavaste, viñas y olivares que \add tú\add* no plantaste: y comieres, y te hartares;
 \v 12 Guárdate que no te olvides de Jehová, que te sacó de tierra de Egipto de casa de siervos.
 \v 13 A Jehová tu Dios temerás, y a él servirás y por su nombre jurarás:
@@ -330,7 +330,7 @@
 \v 18 Que hace derecho al huérfano y a la viuda: que ama también al extranjero dándole pan y vestido.
 \v 19 ¶ Amaréis pues al extranjero: porque extranjeros fuisteis vosotros en tierra de Egipto.
 \v 20 ¶ A Jehová tu Dios temerás, a él servirás, a él te allegarás, y por su nombre jurarás.
-\v 21 El \add será\add* tu alabanza, y él \add será\add* tu Dios, que ha hecho contigo estas grandes y terribles cosas, que tus ojos han visto.
+\v 21 Él \add será\add* tu alabanza, y él \add será\add* tu Dios, que ha hecho contigo estas grandes y terribles cosas, que tus ojos han visto.
 \v 22 Con setenta almas descendieron tus padres a Egipto, y ahora Jehová te ha hecho como las estrellas del cielo en multitud.
 \c 11
 \v 1 Amarás pues a Jehová tu Dios, y guardarás su observancia, y sus estatutos y sus derechos, y sus mandamientos todos los días.
@@ -796,7 +796,7 @@
 \v 41 Hijos e hijas engendrarás, y no serán para ti, porque irán en cautiverio.
 \v 42 Toda tu arboleda y el fruto de tu tierra consumirá la langosta.
 \v 43 El extranjero que \add estará\add* en medio de ti subirá sobre ti encima, encima: y tú descenderás abajo, abajo.
-\v 44 El te prestara a ti, y tú no prestarás a él: él será por cabeza, y tú serás por cola.
+\v 44 Él te prestara a ti, y tú no prestarás a él: él será por cabeza, y tú serás por cola.
 \v 45 Y vendrán sobre ti todas estas maldiciones, y perseguirte han, y alcanzarte han hasta que perezcas: por cuanto no habrás oído a la voz de Jehová tu Dios guardando sus mandamientos y sus estatutos, que él te mandó.
 \v 46 Y serán en ti por señal y por milagro, y en tu simiente para siempre:
 \v 47 Por cuanto no serviste a Jehová tu Dios con alegría y con bondad de corazón por la abundancia de todas las cosas.
@@ -807,7 +807,7 @@
 \v 52 Y ponerte ha cerco en todas tus ciudades, hasta que caigan tus muros altos y encastillados, en que tú confías, en toda tu tierra: y cercarte ha en todas tus ciudades y en toda tu tierra, que Jehová tu Dios te dió.
 \v 53 Y comerás el fruto de tu vientre, la carne de tus hijos y de tus hijas, que Jehová tu Dios te dió, en el cerco y en la angustia con que te angustiará tu enemigo.
 \v 54 El hombre tierno en ti y el muy delicado, su ojo será maligno para con su hermano, y para con la mujer de su seno, y para con el resto de sus hijos, que le quedaren;
-\v 55 Para no dar a alguno de ellos de la carne de sus hijos, que el comerá, porque no le habrá quedado en el cerco, y en la apretura con que tu enemigo te apretará en todas tus ciudades.
+\v 55 Para no dar a alguno de ellos de la carne de sus hijos, que él comerá, porque no le habrá quedado en el cerco, y en la apretura con que tu enemigo te apretará en todas tus ciudades.
 \v 56 La tierna en ti y la delicada, que nunca la planta de su pie probó a estar sobre la tierra de ternura y delicadez, su ojo será maligno para con el marido de su seno, y para con su hijo y para con su hija,
 \v 57 Y para con su chiquita que sale de entre sus pies, y para con sus hijos que pariere, que los comerá escondidamente con necesidad de todas las cosas en el cerco y en la apretura con que tu enemigo te apretará en tus ciudades.
 \v 58 Si no guardares para hacer todas las palabras de aquesta ley, que están escritas en este libro, temiendo este nombre glorioso y terrible: Jehová tu Dios;
@@ -973,11 +973,11 @@
 \v 14 Y por los regalos de los frutos del sol, y por los regalos de las influencias de las lunas,
 \v 15 Y por la cumbre de los montes antiguos; y por los regalos, de los collados eternos.
 \v 16 Y por los regalos de la tierra, y su plenitud: y la gracia del que habitó en la zarza venga sobre la cabeza de José, y sobre la mollera del apartado de sus hermanos.
-\v 17 El es hermoso como el primogénito de su buey: y sus cuernos, cuernos de unicornio: con ellos acorneará los pueblos a una, hasta los fines de la tierra: y estos \add son\add* los diez millares de Efraím: y estos los millares de Manasés.
+\v 17 Él es hermoso como el primogénito de su buey: y sus cuernos, cuernos de unicornio: con ellos acorneará los pueblos a una, hasta los fines de la tierra: y estos \add son\add* los diez millares de Efraím: y estos los millares de Manasés.
 \v 18 Y a Zabulón dijo: Alégrate Zabulón cuando salieres; e Isacar en tus tiendas.
 \v 19 Al monte llamarán pueblos, allí sacrificarán sacrificios de justicia: por lo cual chuparán la abundancia de las mares, y los tesoros escondidos del arena.
 \v 20 Y a Gad dijo: Bendito el que hizo ensanchar a Gad: como león habitará, y arrebatará brazo y mollera.
-\v 21 El vio para sí lo primero, que allí estaba escondida la parte del legislador, y vino en la delantera del pueblo: la justicia de Jehová hará, y sus juicios con Israel.
+\v 21 Él vio para sí lo primero, que allí estaba escondida la parte del legislador, y vino en la delantera del pueblo: la justicia de Jehová hará, y sus juicios con Israel.
 \v 22 Y a Dan dijo: Dan, cachorro de león: saltará desde Basán.
 \v 23 Y a Neftalí dijo: Neftalí harto de voluntad, y lleno de bendición de Jehová; el occidente y el mediodía hereda.
 \v 24 Y a Aser dijo: Bendito más que los hijos, Aser; será agradable a sus hermanos: y mojará en aceite su pie.

--- a/USFM/06_JOS_RV1865.usfm
+++ b/USFM/06_JOS_RV1865.usfm
@@ -390,7 +390,7 @@
 \v 16 Y dijo Caleb: Al que hiriere a Cariat-sefer, y la tomare, \add yo\add* le daré a mi hija Aja por mujer.
 \v 17 Y tomóla Otoniel hijo de Cenez hermano de Caleb: y él le dio por mujer a su hija Aja:
 \v 18 Y aconteció \add que\add* cuando la llevaban, él la persuadió que pidiese a su padre tierras para labrar. Ella entonces descendió del asno. Y Caleb le dijo: ¿Qué tienes?
-\v 19 Y ella respondió. Dáme \add alguna\add* bendición: pues que me has dado tierra de secadal, dáme también fuentes de aguas. El entonces le dio las fuentes de arriba, y las de abajo.
+\v 19 Y ella respondió. Dáme \add alguna\add* bendición: pues que me has dado tierra de secadal, dáme también fuentes de aguas. Él entonces le dio las fuentes de arriba, y las de abajo.
 \v 20 Esta pues es la herencia de la tribu de los hijos de Judá por sus familias.
 \v 21 Y fueron las ciudades del término de la tribu de los hijos de Judá hacia el término de Edom al mediodía, Cabseel, y Eder, y Jagur,
 \v 22 Y Cina, y Demona, y Adada,
@@ -592,7 +592,7 @@
 \v 33 Todas las villas de los Gersonitas por sus familias \add fueron\add* trece villas con sus ejidos.
 \v 34 Y a las familias de los hijos de Merari, Levitas, que quedaban, de la tribu de Zabulón \add les fueron dadas\add* Jecnam con sus ejidos, Carta con sus ejidos,
 \v 35 Danna con sus ejidos, Naalot con sus ejidos; cuatro villas.
-\v 36 Y de la tribu de Rubén, a Bosor con sus edijos, Jahesa con sus ejidos,
+\v 36 Y de la tribu de Rubén, a Bosor con sus ejidos, Jahesa con sus ejidos,
 \v 37 Cedmod con sus ejidos, Mefaat con sus ejidos; cuatro villas.
 \v 38 De la tribu de Gad, la villa del refugio para los homicidas, Ramot en Galaad con sus ejidos, y Mahanaim con sus ejidos,
 \v 39 Jesebón con sus ejidos, y Jazer con sus ejidos; cuatro villas.

--- a/USFM/07_JDG_RV1865.usfm
+++ b/USFM/07_JDG_RV1865.usfm
@@ -86,8 +86,8 @@
 \v 16 Y Aod se había hecho un cuchillo agudo de ambas partes de longura de un codo: y traíalo ceñido debajo de sus vestidos a su lado derecho.
 \v 17 Y presentó el presente a Eglón rey de Moab: y Eglón \add era\add* hombre muy grueso:
 \v 18 Y luego que él hubo presentado el presente, envió al pueblo que habían traído el presente.
-\v 19 Y tornándose desde los ídolos que \add están\add* en Galgala, dijo: Rey, una palabra secreta tengo que decirte. El entonces dijo: Calla. Y saliéronse de delante de él todos los que estaban delante de él.
-\v 20 Y Aod entró a él, el cual estaba sentado solo en una sala de verano. Y Aod dijo: Tengo palabra de Dios para ti. El entonces se levantó de la silla.
+\v 19 Y tornándose desde los ídolos que \add están\add* en Galgala, dijo: Rey, una palabra secreta tengo que decirte. Él entonces dijo: Calla. Y saliéronse de delante de él todos los que estaban delante de él.
+\v 20 Y Aod entró a él, el cual estaba sentado solo en una sala de verano. Y Aod dijo: Tengo palabra de Dios para ti. Él entonces se levantó de la silla.
 \v 21 Mas Aod metió su mano izquierda, y tomó el cuchillo de su lado derecho, y metióselo por el vientre,
 \v 22 De tal manera que la empuñadura entró también tras la hoja, y la grosura encerró la hoja, que él no sacó el cuchillo de su vientre: y el estiércol salió.
 \v 23 Y saliendo Aod al patio cerró tras sí las puertas de la sala.
@@ -122,7 +122,7 @@
 \v 20 Y él la dijo: Estáte a la puerta de la tienda, y si alguno viniere, y te preguntare, diciendo: ¿Hay aquí alguno? tú responderás que no.
 \v 21 Y Jahel la mujer de Jeber tomó la estaca de la tienda, y poniendo un mazo en su mano, vino a él calladamente, y metióle la estaca por las sienes, y enclavóle con la tierra: y él estaba cargado del sueño y cansado, y \add así\add* murió.
 \v 22 Y siguiendo Barac a Sísera, Jahel le salió a recibir, y díjole: Ven, y mostrarte he al varón, que tú buscas; y él entró donde ella estaba, y, he aquí, Sísera \add estaba\add* tendido muerto, la estaca atravesada por la sien.
-\v 23 Y aquel día sujeto Dios a Jabín rey de Canaán delante de los hijos de Israel.
+\v 23 Y aquel día sujetó Dios a Jabín rey de Canaán delante de los hijos de Israel.
 \v 24 Y la mano de los hijos de Israel comenzó a crecer, y a fortificarse contra Jabín rey de Canaán hasta que le destruyeron.
 \c 5
 \v 1 Y aquel día cantó Débora y Barac hijo de Abinoem, diciendo:
@@ -149,7 +149,7 @@
 \v 22 Las uñas de los caballos se embotaron entonces, por los encuentros, los encuentros de sus valientes.
 \v 23 Maldecíd a Meros, dijo el ángel de Jehová: maldecíd con maldición a sus moradores: porque no vinieron en socorro a Jehová, en socorro a Jehová contra los fuertes.
 \v 24 Bendita sea sobre las mujeres Jahel la mujer de Jeber Cineo: sobre las mujeres sea bendita en la tienda.
-\v 25 El pidió agua, y \add ella le\add* dio leche: en tazón de nobles le presentó manteca.
+\v 25 Él pidió agua, y \add ella le\add* dio leche: en tazón de nobles le presentó manteca.
 \v 26 Su mano tendió a la estaca, y su diestra al mazo de trabajadores, y majó a Sísera; hirió su cabeza; llagó, y pasó sus sienes.
 \v 27 Cayó encorvado entre sus pies, quedó tendido: entre sus pies cayó encorvado: donde se encorvó, allí cayó muerto.
 \v 28 La madre de Sísera asomándose a la ventana aulla, \add mirando\add* por entre las rejas, \add diciendo\add*: ¿Por qué se detiene su carro, que no viene? ¿por qué se tardan las ruedas de sus carros?
@@ -171,7 +171,7 @@
 \v 12 Y el ángel de Jehová se le apareció, y díjole: Jehová \add es\add* contigo varón valiente de fuerza.
 \v 13 Y Gedeón le respondió: Ay, Señor mío, si Jehová es con nosotros; ¿por qué nos ha comprendido todo esto? ¿Y dónde \add están\add* todas sus maravillas, que nuestros padres nos han contado, diciendo: No nos sacó Jehová de Egipto? Y ahora Jehová nos ha desamparado, y nos ha entregado en mano de los Madianitas.
 \v 14 Y mirándole Jehová, díjole: Anda, vé con esta tu fortaleza, y salvarás a Israel de la mano de los Madianitas. ¿No te envío \add yo\add*?
-\v 15 El entonces le respondió: Ay, Señor mío, ¿con qué tengo de salvar a Israel? He aquí que mi familia \add es\add* pobre en Manasés: y yo el menor en la casa de mi padre.
+\v 15 Él entonces le respondió: Ay, Señor mío, ¿con qué tengo de salvar a Israel? He aquí que mi familia \add es\add* pobre en Manasés: y yo el menor en la casa de mi padre.
 \v 16 Y Jehová le dijo: Porque \add yo\add* seré contigo; y \add tú\add* herirás a los Madianitas, como a un varón.
 \v 17 Y él respondió: Yo te ruego, que, si he hallado gracia delante de ti, me des señal, de que tú has hablado conmigo.
 \v 18 Ruégote, que no te vayas de aquí hasta que \add yo\add* vuelva a ti, y saque mi presente, y lo ponga delante de ti. Y él respondió: Yo esperaré hasta que vuelvas.
@@ -335,7 +335,7 @@
 \v 15 Y los hijos de Israel respondieron a Jehová: \add Nosotros\add* hemos pecado, haz tú con nosotros como bien te pareciere: solamente que ahora nos libres en este día.
 \v 16 Y quitaron de entre sí los dioses ajenos, y sirvieron a Jehová; y su alma fue angustiada a causa del trabajo de Israel.
 \v 17 Y juntándose los hijos de Ammón asentaron campo en Galaad: y juntáronse los hijos de Israel, y asentaron su campo en Maspa.
-\v 18 Y los príncipes y el pueblo de Galaad dijeron el uno al otro: ¿Quién será el que comenzará la batalla contra los hijos de Ammón? El será cabeza sobre todos los que habitan en Galaad.
+\v 18 Y los príncipes y el pueblo de Galaad dijeron el uno al otro: ¿Quién será el que comenzará la batalla contra los hijos de Ammón? Él será cabeza sobre todos los que habitan en Galaad.
 \c 11
 \v 1 Entonces Jefté Galaadita era hombre valiente, hijo de una ramera, al cual Jefté había engendrado Galaad.
 \v 2 Y la mujer de Galaad \add también\add* le había parido hijos: los cuales cuando fueron grandes echaron \add de sí a\add* Jefté, diciendo: No heredarás en la casa de nuestro padre, porque eres bastardo.
@@ -374,7 +374,7 @@
 \v 35 Y como él la vio, rompió sus vestidos, diciendo: Ay, hija mía, de verdad me has abatido, y tú eres de los que me abaten: porque \add yo\add* he abierto mi boca a Jehová, y no lo podré revocar.
 \v 36 Ella entonces le respondió: Padre mío, si has abierto tu boca a Jehová, haz de mí como salió de tu boca, pues que Jehová te ha hecho venganza de tus enemigos los hijos de Ammón.
 \v 37 Y tornó a decir a su padre: Hágasme esto: déjame por dos meses que vaya y descienda por los montes, y llore mi virginidad, yo y mis compañeras.
-\v 38 El entonces dijo: Vé. Y dejóla por dos meses: y ella fue con sus compañeras, y lloró su virginidad por los montes.
+\v 38 Él entonces dijo: Vé. Y dejóla por dos meses: y ella fue con sus compañeras, y lloró su virginidad por los montes.
 \v 39 Pasados los dos meses, volvió a su padre, e hizo de ella \add conforme\add* a su voto, que había votado: y ella nunca conoció varón.
 \v 40 De aquí fue la costumbre en Israel \add que\add* de año en año iban las hijas de Israel, para endechar a la hija de Jefté Galaadita, cuatro días en el año.
 \c 12
@@ -474,7 +474,7 @@
 \v 10 Entonces Dalila dijo a Samsón: He aquí, tú me has engañado, y me has dicho mentiras: descúbreme pues ahora, yo te ruego, como podrás ser atado.
 \v 11 Y él le dijo: Si me ataren fuertemente con cuerdas nuevas, con las cuales ninguna cosa se haya hecho, yo me enflaqueceré, y seré como cualquiera de los \add otros\add* hombres.
 \v 12 Y Dalila tomó cuerdas nuevas, y atóle con ellas: y díjole: Samsón, los Filisteos sobre ti. Y las espías estaban en una cámara. Mas él las rompió de sus brazos como un hilo.
-\v 13 Y Dalila dijo a Samsón: Hasta ahora me engañas y tratas conmigo con mentiras. Descúbreme pues ahora como podrás ser atado. El entonces le dijo: Si tejieres siete guedejas de mi cabeza con la tela.
+\v 13 Y Dalila dijo a Samsón: Hasta ahora me engañas y tratas conmigo con mentiras. Descúbreme pues ahora como podrás ser atado. Él entonces le dijo: Si tejieres siete guedejas de mi cabeza con la tela.
 \v 14 Y \add ella\add* hincó la estaca, y díjole: Samsón, los Filisteos sobre ti. Mas despertándose él de su sueño, arrancó la estaca del telar con la tela.
 \v 15 Y \add ella\add* le dijo: ¿Cómo dices: \add Yo\add* te amo: pues que tu corazón no \add está\add* conmigo? Ya me has engañado tres veces, y no me has aun descubierto en que \add está\add* tu gran fuerza.
 \v 16 Y aconteció, que apretándole ella cada día con sus palabras, y moliéndole, su alma se angustió para la muerte.
@@ -492,7 +492,7 @@
 \v 28 Y Samsón clamó a Jehová y dijo: Señor Jehová, acuérdate ahora de mí, y esfuérzame ahora solamente esta vez ¡Oh Dios! para que de una vez tome venganza de los Filisteos de mis dos ojos.
 \v 29 Entonces Samsón se abrazó con las dos columnas del medio sobre las cuales se sustentaba la casa, y estribó en ellas, la una con la mano derecha, y la otra con la izquierda.
 \v 30 Y \add haciendo esto\add*, dijo Samsón: Muera mi alma con los Filisteos. Y estribando con esfuerzo cayó la casa sobre los príncipes, y sobre todo el pueblo que \add estaba\add* en ella. Y fueron muchos más los que de ellos mató muriendo, que los que había muerto en su vida.
-\v 31 Y descendieron sus hermanos, y toda la casa de su padre, y tomáronle, y lleváronle, y sepultáronle entre Saraa, y Estaol en el sepulcro de su padre Manue: y el juzgó a Israel veinte años.
+\v 31 Y descendieron sus hermanos, y toda la casa de su padre, y tomáronle, y lleváronle, y sepultáronle entre Saraa, y Estaol en el sepulcro de su padre Manue: y él juzgó a Israel veinte años.
 \c 17
 \v 1 Fue un varón del monte de Efraím, que se llamaba Micas:
 \v 2 El cual dijo a su madre: Los mil y cien \add siclos\add* de plata, que te fueron hurtados, y tú maldecias, oyéndolo yo, he aquí que yo tengo este dinero: yo lo había tomado. Entonces la madre dijo: Bendito \add seas\add* de Jehová, hijo mío.

--- a/USFM/09_1SA_RV1865.usfm
+++ b/USFM/09_1SA_RV1865.usfm
@@ -43,8 +43,8 @@
 \v 5 Los hartos se alquilaron por pan: y los hambrientos cesaron: hasta parir siete la estéril, y la que tenía muchos hijos enfermó.
 \v 6 Jehová mata, y él da vida: él hace descender a los infiernos, y hace subir.
 \v 7 Jehová empobrece, y él enriquece: abate, y ensalza.
-\v 8 El levanta del polvo al pobre, y al menesteroso ensalza del estiércol, para asentarle con los príncipes: y hace que tengan por heredad asiento de honra: porque de Jehová son las columnas de la tierra, y \add él\add* asentó sobre ellas el mundo.
-\v 9 El guarda los pies de sus santos; mas los impíos perecen en tinieblas, porque nadie con fuerza será valiente.
+\v 8 Él levanta del polvo al pobre, y al menesteroso ensalza del estiércol, para asentarle con los príncipes: y hace que tengan por heredad asiento de honra: porque de Jehová son las columnas de la tierra, y \add él\add* asentó sobre ellas el mundo.
+\v 9 Él guarda los pies de sus santos; mas los impíos perecen en tinieblas, porque nadie con fuerza será valiente.
 \v 10 Jehová, serán quebrantados sus adversarios: y sobre ellos tronará desde los cielos: Jehová juzgará los términos de la tierra, y dará fortaleza a su rey, y ensalzará el cuerno de su Mesías.
 \v 11 Y Elcana se volvió a su casa en Ramata: y el mozo ministraba a Jehová delante de Elí sacerdote.
 \v 12 ¶ Mas los hijos de Elí eran hombres impíos, y no tenían conocimiento de Jehová.
@@ -185,8 +185,8 @@
 \v 12 Y ponérselos ha por coroneles, y cincuenteneros; y que aren sus aradas, y sieguen sus siegas, y que hagan sus armas de guerra, y los pertrechos de sus carros.
 \v 13 Ítem, tomará vuestras hijas, para que sean ungüenteras, cocineras, y amasadoras.
 \v 14 Asimismo tomará vuestras tierras, vuestras viñas, y vuestros buenos olivares, y dará a sus siervos.
-\v 15 El diezmará vuestras simientes, y vuestras viñas, para dar a sus eunucos, y a sus siervos.
-\v 16 El tomará vuestros siervos, y vuestras siervas, y vuestros buenos mancebos, y vuestros asnos, y con ellos hará sus obras.
+\v 15 Él diezmará vuestras simientes, y vuestras viñas, para dar a sus eunucos, y a sus siervos.
+\v 16 Él tomará vuestros siervos, y vuestras siervas, y vuestros buenos mancebos, y vuestros asnos, y con ellos hará sus obras.
 \v 17 Diezmará también vuestro rebaño, y \add finalmente\add* seréis sus siervos.
 \v 18 Y clamaréis aquel día a causa de vuestro rey que os habréis elegido: mas Jehová no os oirá en aquel día.
 \v 19 Mas el pueblo no quiso oír la voz de Samuel, antes dijeron: No, sino rey será sobre nosotros.
@@ -201,7 +201,7 @@
 \v 5 Y cuando vinieron a la tierra de Suf, Saul dijo a su criado que tenía consigo: Ven, volvámosnos porque quizá mi padre, dejadas las asnas, estará congojado por nosotros.
 \v 6 Y él le respondió: He aquí ahora que en esta ciudad \add está\add* el varón de Dios, que es varón insigne: todas las cosas que él dijere, sin duda vendrán. Vamos ahora allá: quizá nos enseñará nuestro camino por donde vayamos.
 \v 7 Y Saul respondió a su criado: Vamos pues: mas ¿qué llevaremos al varón? Porque el pan de nuestras alforjas se ha acabado, y no tenemos que presentar al varón de Dios: \add porque\add* ¿qué tenemos?
-\v 8 Entonces tornó el criado a responder a Saul, diciendo: He aquí, se halla en mi mano un cuatro de siclo de plata; esto daré al varón de Dios, porque nos declare nuestro camino.
+\v 8 Entonces tornó el criado a responder a Saul, diciendo: He aquí, se halla en mi mano un cuarto de siclo de plata; esto daré al varón de Dios, porque nos declare nuestro camino.
 \v 9 (Antiguamente en Israel cualquiera que iba a consultar a Dios, decía así: Veníd y vamos hasta el vidente; porque el que ahora \add se llama\add* profeta, antiguamente era llamado, vidente.)
 \v 10 Dijo pues Saul a su criado: Bien dices: ea pues vamos. Y fueron a la ciudad, donde \add estaba\add* el varón de Dios:
 \v 11 Y cuando subían por la cuesta de la ciudad, hallaron \add unas\add* mozas que salían por agua, a las cuales dijeron: ¿Está en este lugar el vidente?
@@ -672,7 +672,7 @@
 \v 12 Juzgue Jehová entre mí y ti, y véngueme de ti Jehová, que mi mano no sea contra ti.
 \v 13 Como dice el proverbio del antiguo: De los impíos saldrá la impiedad: por tanto mi mano no será contra ti.
 \v 14 ¿Tras quién ha salido el rey de Israel? ¿A quién persigues? ¿A un perro muerto? ¿a una pulga?
-\v 15 Jehová pues será juez, y él juzgará entre mí y ti. El vea y pleitee mi pleito, y me defienda de tu mano.
+\v 15 Jehová pues será juez, y él juzgará entre mí y ti. Él vea y pleitee mi pleito, y me defienda de tu mano.
 \v 16 Y aconteció, que como David acabó de decir estas palabras a Saul: Saul dijo: ¿No es esta tu voz, hijo mío, David? Y alzando Saul su voz, lloró.
 \v 17 Y dijo a David: Más justo \add eres\add* tú que yo, que me has pagado con bien, habiéndote yo pagado con mal.
 \v 18 Tú has mostrado hoy que has hecho conmigo bien; pues no me has muerto, habiéndome Jehová puesto en tus manos.
@@ -705,7 +705,7 @@
 \v 22 Así haga Dios, y así añada a los enemigos de David, que no tengo de dejar de todo lo que fuere suyo de aquí a mañana meante a la pared.
 \v 23 Y como Abigail vio a David, descendió prestamente del asno, y postrándose delante de David sobre su rostro, inclinóse a tierra:
 \v 24 Y echándose a sus pies, dijo: Señor mío, en mí \add sea este\add* pecado: por tanto ahora hable tu sierva en tus oídos, y oye las palabras de tu sierva.
-\v 25 No ponga ahora mi señor su corazón a aquel hombre impío, a Nabal; porque conforme a su nombre, así es. El se llama Nabal, y la locura \add está\add* con él; porque yo tu sierva no ví a los criados de mi señor, que enviaste.
+\v 25 No ponga ahora mi señor su corazón a aquel hombre impío, a Nabal; porque conforme a su nombre, así es. Él se llama Nabal, y la locura \add está\add* con él; porque yo tu sierva no ví a los criados de mi señor, que enviaste.
 \v 26 Ahora pues, señor mío, vive Jehová, y viva tu alma, que Jehová te ha vedado, que vengas contra sangre, y que tu mano te salve. Tus enemigos pues sean como Nabal, y todos los que procuran mal contra mi señor.
 \v 27 Ahora pues esta bendición que tu sierva ha traído a mi señor, dése a los criados que siguen a mi señor:
 \v 28 Y yo te ruego que perdones a tu sierva \add esta\add* maldad; porque Jehová hará casa firme a mi señor, por cuanto mi señor hace las guerras de Jehová, y mal no se ha hallado en ti en tus días.
@@ -763,7 +763,7 @@
 \v 9 Y hería David la tierra, y no dejaba a vida hombre ni mujer: y llevábase las ovejas, y las vacas, y los asnos, y los camellos, y las ropas, y volvía, y se venía a Aquis.
 \v 10 Y decía Aquis: ¿Dónde habéis corrido hoy? Y David decía: Al mediodía de Judá, y al mediodía de Jerameel, o contra el mediodía de Ceni.
 \v 11 Ni hombre ni mujer dejaba a vida David, que viniese a Get, diciendo: Porque no den aviso de nosotros, diciendo: Esto hizo David. Y esta era su costumbre todo el tiempo que moró en tierra de los Filisteos.
-\v 12 Y Aquis creía a David, diciendo \add así\add*: El se hace abominable en su pueblo de Israel; y \add así\add* será siempre mi siervo.
+\v 12 Y Aquis creía a David, diciendo \add así\add*: Él se hace abominable en su pueblo de Israel; y \add así\add* será siempre mi siervo.
 \c 28
 \v 1 Y aconteció, que en aquellos días los Filisteos juntaron sus campos para pelear contra Israel. Y dijo Aquis a David: Sepas de cierto, que has de salir conmigo al campo, tú y los tuyos.
 \v 2 Y David respondió a Aquis: Conocerás pues lo que hará tu siervo. Y Aquis dijo a David: Por eso te haré guarda de mi cabeza todos los días.

--- a/USFM/10_2SA_RV1865.usfm
+++ b/USFM/10_2SA_RV1865.usfm
@@ -435,7 +435,7 @@
 \v 7 Y decía Semeí maldiciéndole: Sal: Sal, varón de sangres, y varón impío.
 \v 8 Jehová te ha dado el pago de todas las sangres de la casa de Saul, en lugar del cual tú has reinado: mas Jehová ha entregado el reino en mano de tu hijo Absalom: y, he aquí tú \add eres tomado\add* en tu maldad: porque eres varón de sangres.
 \v 9 Y Abisaí, hijo de Sarvia, dijo al rey: ¿Por qué maldice este perro muerto a mi señor el rey? Yo te ruego que me dejes pasar, y quitarle he la cabeza.
-\v 10 Y el rey respondió: ¿Qué tengo yo con vosotros, hijos de Sarvia? El maldice así, porque Jehová le ha dicho que maldiga a David: ¿quién pues le dirá: Por qué lo haces así?
+\v 10 Y el rey respondió: ¿Qué tengo yo con vosotros, hijos de Sarvia? Él maldice así, porque Jehová le ha dicho que maldiga a David: ¿quién pues le dirá: Por qué lo haces así?
 \v 11 Y dijo David a Abisaí, y a todos sus siervos: He aquí, que mi hijo, que ha salido de mi vientre, asecha a mi vida, ¿cuánto más ahora un hijo de Jemini? Dejádle que maldiga, que Jehová se lo ha dicho.
 \v 12 Quizá Jehová mirará a mi aflicción, y me dará Jehová bien por sus maldiciones hoy.
 \v 13 Y como David y los suyos iban por el camino, Semeí iba por el lado del monte delante de él, andando y maldiciendo, y arrojando piedras delante de él, y esparciendo polvo.
@@ -678,7 +678,7 @@
 \v 16 Entonces \add estos\add* tres valientes rompieron en el campo de los Filisteos, y sacaron del agua de la cisterna de Belén, que \add estaba a\add* la puerta, y tomaron, y trajéronla a David: mas él no la quiso beber, sino derramóla a Jehová, diciendo:
 \v 17 Lejos sea de mí, oh Jehová, que \add yo\add* haga esto. ¿La sangre de los varones que fueron \add por ella\add* con peligro de su vida \add tengo de beber\add*? Y no quiso beber de ella. \add Estos\add* tres valientes hicieron esto.
 \v 18 Y Abisaí hermano de Joab, hijo de Sarvia, \add fue\add* el principal de tres: el cual alzó su lanza contra trescientos, los cuales mató, y tuvo nombre entre los tres.
-\v 19 El fue el más noble de los tres, y el primero de ellos, mas no llegó a los tres \add primeros\add*.
+\v 19 Él fue el más noble de los tres, y el primero de ellos, mas no llegó a los tres \add primeros\add*.
 \v 20 Banaías, hijo de Joiada, hijo de un varón esforzado, grande en hechos, de Cabseel. Este hirió dos leones de Moab. Y él \add mismo\add* descendió, e hirió un león en medio del foso en el tiempo de la nieve.
 \v 21 Y el mismo hirió a un Egipcio, hombre de \add grande\add* estatura; y el Egipcio tenía una lanza en su mano: y él descendió a él con un palo, y arrebató al Egipcio la lanza de la mano, y con su \add misma\add* lanza le mató.
 \v 22 Esto hizo Banaías, hijo de Joiada, y tuvo nombre entre los tres valientes.

--- a/USFM/11_1KI_RV1865.usfm
+++ b/USFM/11_1KI_RV1865.usfm
@@ -77,7 +77,7 @@
 \v 14 Y él dijo: \add Una\add* palabra tengo que decirte. Y ella dijo: Dí. Y él dijo:
 \v 15 Tú sabes que el reino era mío: y que todo Israel había puesto en mi su rostro, para que yo reinara: mas el reino fue traspasado, y vino a mi hermano: porque por Jehová era suyo.
 \v 16 Y ahora yo te pido una petición, no me hagas volver mi rostro. Y ella le dijo: Dí.
-\v 17 El entonces dijo: Yo te ruego que hables al rey Salomón, porque él no te hará volver tu rostro, para que me dé a Abisag Sunamita por mujer.
+\v 17 Él entonces dijo: Yo te ruego que hables al rey Salomón, porque él no te hará volver tu rostro, para que me dé a Abisag Sunamita por mujer.
 \v 18 Y Bersabée dijo: Bien; yo hablaré por ti al rey.
 \v 19 Y vino Bersabée al rey Salomón para hablarle por Adonías: y el rey se levantó para recibirla, y se inclinó a ella, y se tornó a asentar en su trono: e hizo poner una silla a la madre del rey, la cual se sentó a su diestra.
 \v 20 Y ella dijo: Una pequeña petición te demando, no me hagas volver mi rostro. Y el rey le dijo: Pide, madre mía; que yo no te haré volver el rostro.
@@ -487,7 +487,7 @@
 \v 33 Y sacrificó sobre el altar que él había hecho en Bet-el a los quince del mes octavo, el mes que él había inventado de su corazón; e hizo fiesta a los hijos de Israel, y subió al altar para quemar olores.
 \c 13
 \v 1 Y he aquí que un varón de Dios, por palabra de Jehová, vino de Judá a Bet-el: y estando Jeroboam al altar para quemar perfumes.
-\v 2 El clamó contra el altar por palabra de Jehová, y dijo: Altar, altar, así dijo Jehová: He aquí que a la casa de David nacerá un hijo, llamado Josías, el cual sacrificará sobre ti a los sacerdotes de los altos que queman sobre ti perfumes; y sobre ti quemarán huesos de hombres.
+\v 2 Él clamó contra el altar por palabra de Jehová, y dijo: Altar, altar, así dijo Jehová: He aquí que a la casa de David nacerá un hijo, llamado Josías, el cual sacrificará sobre ti a los sacerdotes de los altos que queman sobre ti perfumes; y sobre ti quemarán huesos de hombres.
 \v 3 Y aquel mismo día dio \add una\add* señal diciendo: Esta \add es\add* la señal que Jehová ha hablado: he aquí que el altar se quebrará, y la ceniza que sobre él \add está\add* se derramará.
 \v 4 Y como el rey oyó la palabra del varón de Dios, que había clamado contra el altar en Bet-el, extendiendo su mano desde el altar, Jeroboam dijo: Prendédle: mas la mano, que había extendido contra él, se le secó, que no la pudo tornar a sí.
 \v 5 Y el altar se rompió, y la ceniza se derramó del altar, conforme a la señal que el varón de Dios había dado por palabra de Jehová.
@@ -503,7 +503,7 @@
 \v 15 Y él le dijo: Ven conmigo a casa, y come del pan.
 \v 16 Y él respondió: No podré volver contigo, ni iré contigo: ni tampoco comeré pan, ni beberé agua contigo en este lugar;
 \v 17 Porque por palabra de Dios me ha sido dicho: No comas pan, ni bebas agua allá: ni vuelvas por el camino que fueres.
-\v 18 Y el \add otro\add* le dijo: Yo también soy profeta como tú; y \add un\add* ángel me ha hablado por palabra de Jehová, diciendo: Vuélvele contigo a tu casa, para que coma pan, y bebe agua. Mintióle.
+\v 18 Y el \add otro\add* le dijo: Yo también soy profeta como tú; y \add un\add* ángel me ha hablado por palabra de Jehová, diciendo: Vuélvele contigo a tu casa, para que coma pan, y beba agua. Mintióle.
 \v 19 Entonces volvió con él; y comió del pan en su casa, y bebió del agua.
 \v 20 Y aconteció que estando ellos a la mesa, fue palabra de Jehová al profeta que le había hecho volver:
 \v 21 Y clamó al varón de Dios, que había venido de Judá, diciendo: Así dijo Jehová: Por cuanto has sido rebelde al dicho de Jehová, y no guardaste el mandamiento que Jehová tu Dios te había mandado,
@@ -534,7 +534,7 @@
 \v 11 El que muriere \add de los\add* de Jeroboam en la ciudad, los perros le comerán: y el que muriere en el campo, comerle han las aves del cielo; porque Jehová \add lo\add* ha dicho.
 \v 12 Y tú levántate y vete a tu casa, que en entrando tu pie en la ciudad, el mozo morirá;
 \v 13 Y todo Israel le endechará, y enterrarle han; porque aquel solo de los de Jeroboam entrará en sepultura; por cuanto se ha hallado en él \add alguna\add* cosa buena de Jehová Dios de Israel, en la casa de Jeroboam.
-\v 14 Y Jehová se despartará rey sobre Israel, que talará la casa de Jeroboam en este día: ¿y qué, si ahora?
+\v 14 Y Jehová se despertará rey sobre Israel, que talará la casa de Jeroboam en este día: ¿y qué, si ahora?
 \v 15 Y Jehová herirá a Israel, como la caña que se mueve en las aguas: y él arrancará a Israel de esta buena tierra, que él había dado a sus padres, y esparcirlos ha de la otra parte del río, por cuanto han hecho sus bosques, enojando a Jehová.
 \v 16 Y él entregará a Israel por los pecados de Jeroboam, el cual pecó, y ha hecho pecar a Israel.
 \v 17 Entonces la mujer de Jeroboam se levantó, y se fue, y vino a Tersa: y entrando ella por el umbral de la casa, el mozo murió.
@@ -624,7 +624,7 @@
 \v 34 En su tiempo Hiel de Bet-el reedificó a Jericó. En Abiram su primogénito la fundó: y en Segub su \add hijo\add* postrero puso sus puertas, conforme a la palabra de Jehová que había hablado por Josué, hijo de Nun.
 \c 17
 \v 1 Entonces Elías Tesbita, \add que era\add* de los moradores de Galaad, dijo a Acab: Vive Jehová Dios de Israel, delante del cual \add yo\add* estoy, que no habrá lluvia, ni rocío en estos años, sino por mi palabra.
-\v 2 Y fue palabra de Jehová a el, diciendo:
+\v 2 Y fue palabra de Jehová a él, diciendo:
 \v 3 Apártate de aquí, y vuélvete al oriente, y escóndete en el arroyo de Carit, que \add está\add* antes del Jordán.
 \v 4 Y beberás del arroyo, y yo he mandado a los cuervos, que te den allí de comer.
 \v 5 Y él fue, e hizo conforme a la palabra de Jehová: y fuése y asentó junto al arroyo de Carit, que \add está\add* antes del Jordán.
@@ -734,7 +734,7 @@
 \v 15 Entonces él reconoció los criados de los príncipes de las provincias, los cuales fueron doscientos y treinta y dos. Luego reconoció todo el pueblo, todos los hijos de Israel, \add que fueron\add* siete mil.
 \v 16 Y salieron a mediodía: y Ben-adad \add estaba\add* bebiendo, borracho en las tiendas, él y los reyes: treinta y dos reyes, que habían venido en su ayuda.
 \v 17 Y los criados de los príncipes de las provincias salieron los primeros. Y Ben-adad había enviado quien le dio aviso, diciendo: Varones han salido de Samaria.
-\v 18 El entonces dijo: Si han salido por paz, tomádlos vivos: y si han salido para pelear tomádlos vivos.
+\v 18 Él entonces dijo: Si han salido por paz, tomádlos vivos: y si han salido para pelear tomádlos vivos.
 \v 19 Y los criados de los príncipes de las provincias salieron de la ciudad, y después de ellos el ejército.
 \v 20 E hirió cada uno al que venía contra sí; y los Siros huyeron, siguiéndolos los de Israel, Y el rey de Siria Ben-adad se escapó sobre un caballo, y la gente de a caballo.
 \v 21 Y salió el rey de Israel, e hirió la gente de a caballo y los carros: y deshizo los Siros con grande estrago.
@@ -751,7 +751,7 @@
 \v 32 Y ciñeron sus lomos de sacos, y sogas a sus cabezas, y vinieron al rey de Israel, y dijéronle: Tu siervo Ben-adad dice: Ruégote que me des la vida. Y él respondió: Si él aun vive, mi hermano es.
 \v 33 Esto tomaron \add aquellos\add* varones por buen agüero, y tomaron presto esta palabra de su boca, y dijeron: Ben-adad tu hermano. Y él dijo: Id, y traédmele. Y Ben-adad salió a él, y él le hizo subir en un carro:
 \v 34 Y él le dijo: Las ciudades que mi padre tomo al tuyo, yo las restituiré; y haz plazas en Damasco para ti, como mi padre las hizo en Samaria: y yo me partiré de ti confederado. Y él hizo con él alianza, y envióle.
-\v 35 ¶ Entonces un varón de los hijos de los profetas dijo a su compañero por palabra de Dios: Hiéreme ahora. Y él \add otro\add* varón no le quiso herir.
+\v 35 ¶ Entonces un varón de los hijos de los profetas dijo a su compañero por palabra de Dios: Hiéreme ahora. Y el \add otro\add* varón no le quiso herir.
 \v 36 Y él le dijo: Por cuanto no has obedecido a la palabra de Jehová, he aquí, en apartándote de mí \add un\add* león te herirá. Y como se apartó de él, topóle un león, y le hirió.
 \v 37 Y él topóse con otro varón, y díjole: Hiéreme ahora. Y el \add otro\add* hombre le hirió, y dióle una cuchillada.
 \v 38 Y se fue el profeta, y púsose delante del rey en el camino, y disfrazóse \add poniéndose\add* sobre los ojos un velo.
@@ -786,7 +786,7 @@
 \v 23 De Jezabel también ha hablado Jehová, diciendo: Los perros comerán a Jezabel en la barbacana de Jezrael.
 \v 24 El que de Acab fuere muerto en la ciudad, perros lo comerán: y el que fuere muerto en el campo, comerle han las aves del cielo.
 \v 25 A la verdad ninguno fue como Acab, que \add así\add* se vendiese a hacer lo malo delante de los ojos de Jehová: porque Jezabel su mujer le incitaba.
-\v 26 El fue en grande manera abominable, caminando en pos de los ídolos, conforme a todo lo que hicieron los Amorreos, a los cuales lanzó Jehová delante de los hijos de Israel.
+\v 26 Él fue en grande manera abominable, caminando en pos de los ídolos, conforme a todo lo que hicieron los Amorreos, a los cuales lanzó Jehová delante de los hijos de Israel.
 \v 27 Y fue, cuando Acab oyó estas palabras, rompió sus vestidos, y puso saco sobre su carne, y ayunó, y durmió en saco, y anduvo humillado.
 \v 28 Entonces fue palabra de Jehová a Elías Tesbita, diciendo:
 \v 29 ¿No has visto como Acab se ha humillado delante de mí? Pues por cuanto se ha humillado delante de mí, no traeré el mal en sus días, en los días de su hijo traeré el mal sobre su casa.

--- a/USFM/12_2KI_RV1865.usfm
+++ b/USFM/12_2KI_RV1865.usfm
@@ -9,7 +9,7 @@
 \c 1
 \v 1 Después de la muerte de Acab Moab se rebeló contra Israel:
 \v 2 Y Ocozías cayó por las rejas de una sala \add de la casa\add* que \add tenía\add* en Samaria: y estando enfermo envió mensajeros, y díjoles: Id, y consultád en Baal-zebub dios de Accarón, si tengo de sanar de esta mi enfermedad.
-\v 3 Entonces el ángel de Jehová habló a Elías Tesbita: Levántate, y sube a encontrarte con los mensajeros del rey de Samaria, y decirles has: ¿No hay Dios en Israel, que vosotros vais a consultar a Baal-zebub dios de Accarón:
+\v 3 Entonces el ángel de Jehová habló a Elías Tesbita: Levántate, y sube a encontrarte con los mensajeros del rey de Samaria, y decirles has: ¿No hay Dios en Israel, que vosotros vais a consultar a Baal-zebub dios de Accarón?
 \v 4 Por tanto así dijo Jehová: Del lecho en que subiste no descenderás, antes muriendo morirás. Y Elías \add se\add* fue.
 \v 5 ¶ Y como los mensajeros se volvieron al rey, él les dijo: ¿Por qué pues os habéis vuelto?
 \v 6 Y ellos le respondieron: Encontramos un varón que nos dijo: Id, y volvéos al rey que os envió, y decídle: Así dijo Jehová: ¿No hay Dios en Israel, que tú envías a consultar a Baal-zebub dios de Accarón? Por tanto del lecho en que subiste, no descenderás, antes muriendo morirás.
@@ -120,7 +120,7 @@
 \v 38 ¶ Y volvióse Eliseo a Gálgala. Y hubo grande hambre en la tierra. Entonces los hijos de los profetas estaban con él: y dijo a su criado: Pon una grande olla, y haz potaje para los hijos de los profetas.
 \v 39 Y salió uno al campo a coger yerbas: y halló una parra montés, y cogió de ella uvas monteses su ropa llena: y volvió, y cortólas en la olla del potaje: porque no sabían \add lo que era\add*.
 \v 40 Y echó de comer a los varones: y fue que comiendo ellos de aquel guisado, dieron voces, diciendo: Varón de Dios, la muerte en la olla. Y no lo pudieron comer.
-\v 41 El entonces dijo: Traed harina. Y esparcióla en la olla, y dijo: Echa de comer al pueblo. Y no hubo más mal en la olla.
+\v 41 Él entonces dijo: Traed harina. Y esparcióla en la olla, y dijo: Echa de comer al pueblo. Y no hubo más mal en la olla.
 \v 42 ¶ Ítem, un varón vino de Baal-salisa, el cual trajo al varón de Dios, panes de primicias, veinte panes de cebada, y \add espigas de trigo\add* nuevo en su espiga. Y él dijo: Dá al pueblo, y coman.
 \v 43 Y respondió el que le servía: ¿Cómo pondré esto delante de cien varones? Y él tornó a decir: Dá al pueblo, y coman: porque Jehová dijo así: Comerán, y sobrará.
 \v 44 Entonces él lo puso delante de ellos: y comieron, y sobróles conforme a la palabra de Jehová.
@@ -135,10 +135,10 @@
 \v 8 Y como Eliseo varón de Dios oyó que el rey de Israel había rasgado sus vestidos, envió a decir al rey: ¿Por qué has desgarrado tus vestidos? Venga ahora a mí, y sabrá, que hay profeta en Israel.
 \v 9 Y vino Naamán con su caballería, y con su carro, y paróse a las puertas de la casa de Eliseo.
 \v 10 Y envióle Eliseo un mensajero, diciendo: Vé, y lávate siete veces en el Jordán, y tu carne se te restaurará, y serás limpio.
-\v 11 Y Naamán se fue enojado, diciendo: He aquí, \add yo\add* pensaba en mí: El saldrá luego, y estando en pie invocará el nombre de Jehová su Dios, y alzará su mano, \add y tocará\add* el lugar, y sanará la lepra.
+\v 11 Y Naamán se fue enojado, diciendo: He aquí, \add yo\add* pensaba en mí: Él saldrá luego, y estando en pie invocará el nombre de Jehová su Dios, y alzará su mano, \add y tocará\add* el lugar, y sanará la lepra.
 \v 12 Los ríos de Damasco, Abana y Farfar, ¿no son mejores que todas las aguas de Israel? ¿Si me lavare en ellos, no seré \add también\add* limpio? Y volvióse y fuése enojado.
 \v 13 Entonces sus criados se llegaron a él, y habláronle, diciendo: Padre mío, si el profeta te mandara alguna gran cosa, ¿no la hicieras? ¿cuánto más, diciéndote: Lávate, y serás limpio?
-\v 14 El entonces descendió, y zambullóse siete veces en el Jordán, conforme a la palabra del varón de Dios: y su carne se volvió como la carne de un niño, y fue limpio.
+\v 14 Él entonces descendió, y zambullóse siete veces en el Jordán, conforme a la palabra del varón de Dios: y su carne se volvió como la carne de un niño, y fue limpio.
 \v 15 Y volvió al varón de Dios él y toda su compañía, y púsose delante de él, y dijo: He aquí, ahora conozco, que no hay Dios en toda la tierra, sino en Israel. Ruégote que recibas \add algún\add* presente de tu siervo.
 \v 16 Mas él dijo: Vive Jehová delante del cual estoy, que no tomaré. E importunándole que tomase, él nunca quiso.
 \v 17 Entonces Naamán dijo: Ruégote, ¿no se dará a tu siervo una carga de un par de acémilas de aquesta tierra? porque de aquí adelante tu siervo no sacrificará holocausto ni sacrificio a otros dioses, sino a Jehová.
@@ -150,7 +150,7 @@
 \v 23 Y Naamán dijo: Ruégote que tomes dos talentos. Y él le constriñó, y ató dos talentos de plata en dos sacos, y dos mudas de vestidos, y púsolo a cuestas a dos de sus criados que lo llevasen delante de él.
 \v 24 Y como vino a un lugar secreto, él lo tomó de mano de ellos, y lo guardó en casa, y envió los hombres, que se fuesen.
 \v 25 Y él entró, y púsose delante de su señor. Y Eliseo le dijo: ¿De dónde \add vienes\add* Giezi? Y él dijo: Tu siervo no ha ido a ninguna parte.
-\v 26 El entonces le dijo: ¿No fue también mi corazón, cuando el hombre volvió de su carro a recibirte? ¿Es tiempo de tomar plata, y de tomar vestidos, olivares, viñas, ovejas y bueyes, siervos y siervas?
+\v 26 Él entonces le dijo: ¿No fue también mi corazón, cuando el hombre volvió de su carro a recibirte? ¿Es tiempo de tomar plata, y de tomar vestidos, olivares, viñas, ovejas y bueyes, siervos y siervas?
 \v 27 La lepra de Naamán se te pegará a ti, y a tu simiente para siempre. Y salió de delante de él leproso como la nieve.
 \c 6
 \v 1 Los hijos de los profetas dijeron a Eliseo: He aquí, el lugar en que moramos contigo, nos es estrecho.
@@ -511,7 +511,7 @@
 \v 36 Mas a Jehová, que os sacó de tierra de Egipto con potencia grande, y brazo extendido, a este temeréis, a este adoraréis, a este sacrificaréis.
 \v 37 Los estatutos, y derechos, y ley, y mandamientos que os dio por escrito, guardaréis, haciéndolos todos los días, y no temeréis dioses ajenos.
 \v 38 Y no olvidaréis el concierto que hice con vosotros, ni temeréis dioses ajenos;
-\v 39 Sino a Jehová vuestros Dios teméd, y él os librará de mano de todos vuestros enemigos.
+\v 39 Sino a Jehová vuestro Dios teméd, y él os librará de mano de todos vuestros enemigos.
 \v 40 Mas ellos no oyeron: antes hicieron según su costumbre antigua.
 \v 41 Así temieron a Jehová aquellas gentes, y juntamente sirvieron a sus ídolos: y asimismo sus hijos y sus nietos, como hicieron sus padres, así hacen hasta hoy.
 \c 18
@@ -521,7 +521,7 @@
 \v 4 Este quitó los altos, y quebró las imágines, y taló los bosques, y quebró la serpiente de metal que había hecho Moisés; porque hasta entonces le quemaban perfumes los hijos de Israel, y llamóle por nombre Nehustán.
 \v 5 En Jehová Dios de Israel puso su esperanza: después ni antes de él, no hubo otro como él, en todos los reyes de Judá.
 \v 6 Porque se llegó a Jehová, y no se apartó de él; y guardó los mandamientos que mandó Jehová a Moisés.
-\v 7 Y Jehová fue con él, y en todas las cosas a que salía prosperaba. El se rebeló contra el rey de Asiria, y no le sirvió.
+\v 7 Y Jehová fue con él, y en todas las cosas a que salía prosperaba. Él se rebeló contra el rey de Asiria, y no le sirvió.
 \v 8 Hirió también a los Filisteos hasta Gaza y sus términos, desde las torres de las atalayas hasta la ciudad fortalecida.
 \v 9 En el cuarto año del rey Ezequías, que era el año séptimo de Oséas, hijo de Ela, rey de Israel, subió Salmanasar rey de los Asirios contra Samaria, y cercóla.
 \v 10 Y tomáronla al cabo de tres años, en el sexto año de Ezequías, el cual era el nono año de Oséas rey de Israel, y \add así\add* fue tomada Samaria.
@@ -531,7 +531,7 @@
 \v 14 Entonces Ezequías rey de Judá envió al rey de Asiria en Laquis, diciendo: Yo he pecado; vuélvete de mí, y yo llevaré todo lo que me impusieres. Entonces el rey de Asiria impuso a Ezequías rey de Judá trescientos talentos de plata, y treinta talentos de oro.
 \v 15 Y Ezequías dio toda la plata que fue hallada en la casa de Jehová, y en los tesoros de la casa real.
 \v 16 Entonces rompió Ezequías las puertas del templo de Jehová, y los umbrales que el \add mismo\add* rey Ezequías había cubierto \add de oro\add*, y diólo al rey de Asiria.
-\v 17 Y el rey de Asiria envió a Tartán, y a Rabsaris, y a Rabsaces desde Laquis al rey Ezequías con un grande ejército contra Jerusalem. Y subieron, y vinieron a Jerusalem; y subieron y vinieron, y pararon junto al conduto del estanque de arriba, que \add es\add* en el camino de la heredad del lavador.
+\v 17 Y el rey de Asiria envió a Tartán, y a Rabsaris, y a Rabsaces desde Laquis al rey Ezequías con un grande ejército contra Jerusalem. Y subieron, y vinieron a Jerusalem; y subieron y vinieron, y pararon junto al conducto del estanque de arriba, que \add es\add* en el camino de la heredad del lavador.
 \v 18 Y llamaron al rey, y salió a ellos Eliacim, hijo de Helcías, que era mayordomo, y Sobna escriba, y Joa, hijo de Asaf, canciller.
 \v 19 Y díjoles Rabsaces: Decíd ahora a Ezequías: Así dice el gran rey, el rey de Asiria:
 \v 20 ¿Qué confianza \add es\add* esta en que tú confías? Dices ciertamente: Palabras de labios, consejo, y esfuerzo para la guerra. ¿En qué pues confias ahora, que te has rebelado contra mí?
@@ -584,7 +584,7 @@
 \v 29 Y esto te \add será\add* por señal: Este año comerás lo que nacerá de suyo: y el segundo año lo que \add tornará a\add* nacer de suyo; y el tercer año haréis sementera, y segaréis, y plantaréis viñas, y comeréis el fruto de ellas.
 \v 30 Y lo que hubiere escapado, lo que habrá quedado de la casa de Judá tornará a echar raíz hacia abajo, y hará fruto hacia arriba.
 \v 31 Porque saldrán de Jerusalem residuos, y escapadura del monte de Sión: el celo de Jehová de los ejércitos hará esto.
-\v 32 Por tanto Jehová dice así del rey de Asiria: \add El\add* no entrará en esta ciudad, ni echará saeta en ella: ni vendrá delante de ella escudo: ni será echado contra ella baluarte.
+\v 32 Por tanto Jehová dice así del rey de Asiria: \add Él\add* no entrará en esta ciudad, ni echará saeta en ella: ni vendrá delante de ella escudo: ni será echado contra ella baluarte.
 \v 33 Por el camino que vino, se volverá, y no entrará en esta ciudad, dice Jehová.
 \v 34 Porque \add yo\add* ampararé a esta ciudad para salvarla, por amor de mí, y por amor de David mi siervo.
 \v 35 ¶ Y aconteció \add que\add* la misma noche salió el ángel de Jehová, e hirió en el campo de los Asirios ciento y ochenta y cinco mil \add hombres\add*: y como se levantaron por la mañana, he aquí los cuerpos de los muertos.
@@ -592,7 +592,7 @@
 \v 37 Y aconteció, que estando él adorando en el templo de Nesroc su dios, Adramelec y Sarasar sus hijos le hirieron a cuchillo: y huyéronse a tierra de Ararat, y reinó en su lugar Asaradón su hijo.
 \c 20
 \v 1 En aquellos días Ezequías cayó enfermo a la muerte; y vino a él Isaías profeta, hijo de Amós, y díjole: Jehová dice así: Dispón de tu casa, porque has de morir, y no vivirás.
-\v 2 \add El\add* entonces volvió su rostro a la pared, y oró a Jehová, y dijo:
+\v 2 \add Él\add* entonces volvió su rostro a la pared, y oró a Jehová, y dijo:
 \v 3 Ruégote oh Jehová, ruégote que hayas memoria de que he andado delante de ti en verdad, y en corazón perfecto: y que he hecho las cosas que te agradan. Y lloró Ezequías con gran lloro.
 \v 4 Y antes que Isaías saliese hasta la mitad del patio, fue palabra de Jehová a Isaías, diciendo:
 \v 5 Vuelve, y di a Ezequías príncipe de mi pueblo: Así dice Jehová el Dios de David tu padre: \add Yo\add* he oído tu oración, y he visto tus lágrimas: he aquí, yo te sano: al tercero día subirás a la casa de Jehová.
@@ -652,7 +652,7 @@
 \v 10 Asimismo declaró al rey Safán escriba, diciendo: Helcías el sacerdote me ha dado \add un\add* libro. Y leyólo Safán delante del rey.
 \v 11 Y cuando el rey oyó las palabras del libro de la ley, rompió sus vestidos.
 \v 12 Y mandó el rey a Helcías el sacerdote, y a Ahicam, hijo de Safán, y a Acobor, hijo de Micaia, y a Safán escriba, y a Asaia siervo del rey, diciendo;
-\v 13 Id, y preguntád a Jehová por mí, y por el pueblo, por todo Judá, a cerca de las palabras de este libro, que se ha hallado: porque grande ira de Jehová es la que ha sido encendida contra nosotros; por cuanto nuestros padres no oyeron las palabras de este libro, para hacer conforme a todo lo que nos fue escrito.
+\v 13 Id, y preguntád a Jehová por mí, y por el pueblo, por todo Judá, acerca de las palabras de este libro, que se ha hallado: porque grande ira de Jehová es la que ha sido encendida contra nosotros; por cuanto nuestros padres no oyeron las palabras de este libro, para hacer conforme a todo lo que nos fue escrito.
 \v 14 Entonces fue Helcías el sacerdote, y Ahicam, y Acobor, y Safán, y Asaia, a Holda profetisa, mujer de Sellum, hijo de Tecua, hijo de Araas, guarda de las vestiduras, la cual moraba en Jerusalem en la casa de la doctrina, y hablaron con ella.
 \v 15 Y ella les dijo: Así dijo Jehová el Dios de Israel: Decíd al varón que os envió a mí:
 \v 16 Así dijo Jehová: He aquí, yo traigo mal sobre este lugar, y sobre los que en él moran, \add es a saber\add*, todas las palabras del libro que ha leído el rey de Judá:

--- a/USFM/13_1CH_RV1865.usfm
+++ b/USFM/13_1CH_RV1865.usfm
@@ -210,7 +210,7 @@
 \v 22 Y cayeron muchos heridos, porque la guerra era de Dios, y habitaron en sus lugares hasta la transmigración.
 \v 23 Y los hijos de la media tribu de Manasés habitaron en la tierra desde Basán hasta Baal-hermón, y Sanir, y el monte de Hermón, multiplicados en gran manera.
 \v 24 Y estos \add fueron\add* las cabezas de las casas de sus padres, Efer, Jesí, y Eliel, Ezriel, y Jeremías, y Odoías, y Jediel, hombres valientes, y de esfuerzo, varones de nombres, y cabezas de las casas de sus padres.
-\v 25 Mas se rebelaron contra el Dios de sus padres, y fornicaron siguendo los dioses de los pueblos de la tierra, a los cuales Jehová había quitado de delante de ellos.
+\v 25 Mas se rebelaron contra el Dios de sus padres, y fornicaron siguiendo los dioses de los pueblos de la tierra, a los cuales Jehová había quitado de delante de ellos.
 \v 26 Por lo cual el Dios de Israel despertó el espíritu de Ful rey de los Asirios, y el espíritu de Teglat-palasar rey de los Asirios, el cual trasportó a los Rubenitas y Gaditas, y a la media tribu de Manasés, y los llevó a Halah, y a Habor, y a Ara, y al río de Gozán hasta hoy.
 \c 6
 \v 1 Los hijos de Leví \add fueron\add* Gersón, Caat y Merari.
@@ -683,7 +683,7 @@
 \v 2 Y dijo David: \add Yo\add* haré misericordia con Hanón, hijo de Naas, porque también su padre hizo conmigo misericordia. Así David envió embajadores, que le consolasen de la muerte de su padre. Y venidos los siervos de David en la tierra de los hijos de Ammón a Hanón, para consolarle,
 \v 3 Los príncipes de los hijos de Ammón dijeron a Hanón: ¿Honra \add ahora\add* David a tu padre a tu parecer, que te ha enviado consoladores? ¿No vienen antes sus siervos a ti para escudriñar, e inquirir, y reconocer la tierra?
 \v 4 Entonces Hanón tomó los siervos de David, y rapólos, y cortóles los vestidos por medio hasta las nalgas, y enviólos.
-\v 5 Y \add ellos\add* se fueron, y fue dada la nueva a David de aquellos varones, y él envió a recebirlos, porque estaban muy afrentados. Y díjoles el rey: Estáos en Jericó hasta que os crezca la barba, y entonces volveréis.
+\v 5 Y \add ellos\add* se fueron, y fue dada la nueva a David de aquellos varones, y él envió a recibirlos, porque estaban muy afrentados. Y díjoles el rey: Estáos en Jericó hasta que os crezca la barba, y entonces volveréis.
 \v 6 Y viendo los hijos de Ammón que se habían hecho odiosos a David, envió Hanón y los hijos de Ammón mil talentos de plata, para tomar a sueldo de la Siria de los ríos, y de la Siria de Maaca, y de Soba, carros y gente de a caballo.
 \v 7 Y tomaron a sueldo treinta y dos mil carros, y al rey de Maaca y a su pueblo; los cuales vinieron, y asentaron su campo delante de Medaba. Y juntáronse también los hijos de Ammón de sus ciudades, y vinieron a la guerra.
 \v 8 David oyéndolo, envió a Joab, y a todo el ejército de los valientes \add hombres\add*.

--- a/USFM/14_2CH_RV1865.usfm
+++ b/USFM/14_2CH_RV1865.usfm
@@ -732,7 +732,7 @@
 \v 11 ¿No os engaña Ezequías para entregaros a muerte, a hambre, y a sed, diciendo: Jehová nuestro Dios nos librará de la mano del rey de Asiria?
 \v 12 ¿No es Ezequías el que ha quitado sus altos y sus altares, y dijo a Judá, y a Jerusalem: Delante de este solo altar adoraréis, y sobre él quemaréis perfume?
 \v 13 ¿No habéis sabido lo que yo y mis padres habemos hecho a todos los pueblos de las tierras? ¿Pudieron los dioses de las gentes de las tierras librar su tierra de mi mano?
-\v 14 ¿Qué \add dios\add* hubo de todos los dioses de aquellas gentes que destruyeron mis padres, que puediese librar su pueblo de mis manos? ¿Por qué podrá vuestro Dios escaparos de mi mano?
+\v 14 ¿Qué \add dios\add* hubo de todos los dioses de aquellas gentes que destruyeron mis padres, que pudiese librar su pueblo de mis manos? ¿Por qué podrá vuestro Dios escaparos de mi mano?
 \v 15 Ahora pues no os engañe Ezequías, ni os persuada tal cosa, ni le creáis; que si ningún dios de todas aquellas naciones y reinos pudo librar su pueblo de mis manos, y de las manos de mis padres, ¿cuánto menos vuestros dioses os podrán librar de mi mano?
 \v 16 Y otras cosas hablaron sus siervos contra el Dios Jehová, y contra Ezequías su siervo.
 \v 17 Y además de esto escribió cartas en las cuales blasfemaba a Jehová el Dios de Israel, y hablaba contra él, diciendo: Como los dioses de las gentes de las provincias no pudieron librar su pueblo de mis manos, tampoco el Dios de Ezequías librará al suyo de mis manos.

--- a/USFM/15_EZR_RV1865.usfm
+++ b/USFM/15_EZR_RV1865.usfm
@@ -231,7 +231,7 @@
 \v 30 Y los sacerdotes y Levitas recibieron el peso de la plata, y del oro, y de los vasos, para traerlo a Jerusalem a la casa de nuestro Dios.
 \v 31 Y partimos del río de Ahava a los doce del mes primero, para ir a Jerusalem: y la mano de nuestro Dios fue sobre nosotros, el cual nos libró de mano de enemigo y de asechador en el camino.
 \v 32 Y llegamos a Jerusalem, y reposámos allí tres días.
-\v 33 Y al cuarto día fue pesada la plata, y el oro, y los vasos, en la casa de nuestro Dios por mano de Meremot, hijo de Urías, sacerdote; y con él Eleazar, hijo Finees; y con ellos Jozabad, hijo de Josué, y Noadías, hijo de Bennoi Levita;
+\v 33 Y al cuarto día fue pesada la plata, y el oro, y los vasos, en la casa de nuestro Dios por mano de Meremot, hijo de Urías, sacerdote; y con él Eleazar, hijo de Finees; y con ellos Jozabad, hijo de Josué, y Noadías, hijo de Bennoi Levita;
 \v 34 Por cuenta y por peso por todo: y fue escrito todo aquel peso en aquel tiempo.
 \v 35 Los que habían venido de la cautividad, los hijos de la transmigración, ofrecieron holocaustos al Dios de Israel, becerros doce por todo Israel, carneros noventa y seis, corderos setenta y siete, machos de cabrío por expiación doce, todo en holocausto a Jehová.
 \v 36 Y dieron los privilegios del rey a sus gobernadores y capitanes de la otra parte del río, los cuales ensalzaron el pueblo y la casa de Dios.

--- a/USFM/16_NEH_RV1865.usfm
+++ b/USFM/16_NEH_RV1865.usfm
@@ -21,7 +21,7 @@
 \c 2
 \v 1 Y fue en el mes de Nisán, en el año veinte del rey Artaxerxes, el vino estaba delante de él; y tomé el vino, y di al rey: y no había estado triste delante de él.
 \v 2 Y díjome el rey: ¿Por qué es triste tu rostro, pues no estás enfermo? No \add es\add* esto sino mal de corazón. Entonces temí en gran manera,
-\v 3 Y dije al rey: El rey viva para siempre: ¿por qué no será triste mi rostro, pues que la ciduad, \add que es\add* casa de los sepulcros de mis padres, es desierta, y sus puertas consumidas de fuego?
+\v 3 Y dije al rey: El rey viva para siempre: ¿por qué no será triste mi rostro, pues que la ciudad, \add que es\add* casa de los sepulcros de mis padres, es desierta, y sus puertas consumidas de fuego?
 \v 4 Y díjome el rey: ¿Por qué cosa demandas? Entonces oré al Dios de los cielos,
 \v 5 Y dije al rey: Si al rey place, y si agrada tu siervo delante de ti, demando que me envíes en Judá a la ciudad de los sepulcros de mis padres, y reedificarle he.
 \v 6 Entonces el rey me dijo, (y la reina estaba sentada junto a él:) ¿Hasta cuándo será tu viaje, y cuándo volverás? Y plugo al rey, y envióme, y \add yo\add* le di tiempo.

--- a/USFM/18_JOB_RV1865.usfm
+++ b/USFM/18_JOB_RV1865.usfm
@@ -86,7 +86,7 @@
 \v 13 En imaginaciones de visiones nocturnas, cuando el sueño cae sobre los hombres,
 \v 14 Un espanto, y un temblor me sobrevino, que espantó todos mis huesos.
 \v 15 Y un espíritu pasó por delante de mí, que el pelo de mi carne se erizó.
-\v 16 Paróse una fantasma delante de mis ojos, cuyo rostro yo no conocí; y callando, oí que decía:
+\v 16 Paróse un fantasma delante de mis ojos, cuyo rostro yo no conocí; y callando, oí que decía:
 \v 17 ¿Si será el hombre más justo que Dios? ¿Si será el varón más limpio que el que le hizo?
 \v 18 He aquí que en sus siervos no confía; y en sus ángeles puso locura:
 \v 19 ¿Cuánto más en los que habitan en casas de lodo, cuyo fundamento \add está\add* en el polvo, \add y que\add* serán quebrantados de la polilla?
@@ -110,7 +110,7 @@
 \v 15 Y libra de la espada al pobre, de la boca de los impíos, y de la mano violenta.
 \v 16 Que es esperanza al menesteroso, y la iniquidad cerró su boca.
 \v 17 ¶ He aquí, que bienaventurado es el hombre a quien Dios castiga: por tanto no menosprecies la corrección del Todopoderoso.
-\v 18 Porque él es el que hace la llaga, y \add él que la\add* ligará: el hiere, y sus manos curan.
+\v 18 Porque él es el que hace la llaga, y \add él que la\add* ligará: él hiere, y sus manos curan.
 \v 19 En seis tribulaciones te librará, y en la séptima no te tocará el mal.
 \v 20 En la hambre te redimirá de la muerte, y en la guerra, de las manos de la espada.
 \v 21 Del azote de la lengua serás encubierto: ni temerás de la destrucción, cuando viniere.
@@ -188,7 +188,7 @@
 \v 12 ¿Aun él en su verdura no será cortado, y antes de toda yerba se secará?
 \v 13 Tales \add son\add* los caminos de todos los que olvidan a Dios; y la esperanza del impío perecerá.
 \v 14 Porque su esperanza será cortada, y su confianza es casa de araña.
-\v 15 El estribará sobre su casa, mas no permanecerá en pie: recostarse ha sobre ella, mas no se afirmará.
+\v 15 Él estribará sobre su casa, mas no permanecerá en pie: recostarse ha sobre ella, mas no se afirmará.
 \v 16 \add Un árbol\add* está verde delante del sol, y sus renuevos salen sobre su huerto:
 \v 17 Junto a \add una\add* fuente sus raíces se van entretejiendo, y enlazándose hasta un lugar pedregoso.
 \v 18 Si le arrancaren de su lugar, y negare de él, \add diciendo\add*: Nunca te vi:
@@ -200,7 +200,7 @@
 \v 1 Y respondió Job, y dijo:
 \v 2 Ciertamente yo conozco que \add es\add* así: ¿y como se justificará el hombre con Dios?
 \v 3 Si quisiere contender con él, no le podrá responder a una \add cosa\add* de mil.
-\v 4 El es sabio de corazón, y fuerte de fuerza: ¿quién fue duro contra él, y quedó en paz?
+\v 4 Él es sabio de corazón, y fuerte de fuerza: ¿quién fue duro contra él, y quedó en paz?
 \v 5 Que arranca los montes con su furor, y no conocen quien los trastornó.
 \v 6 Que remueve la tierra de su lugar, y hace temblar sus columnas.
 \v 7 Que manda al sol, y no sale; y a las estrellas sella.
@@ -266,7 +266,7 @@
 \v 8 Es más alto que los cielos, ¿qué harás? es más profundo que el infierno, ¿cómo le conocerás?
 \v 9 Su medida es más larga que la tierra, y más ancha que la mar.
 \v 10 Si cortare, o encerrare, o juntare, ¿quién le responderá?
-\v 11 Porque el conoce a los hombres vanos: y ve la iniquidad, ¿y no entenderá?
+\v 11 Porque él conoce a los hombres vanos: y ve la iniquidad, ¿y no entenderá?
 \v 12 ¶ El hombre vano se hará entendido, aunque nazca como el pollino del asno montés.
 \v 13 Si tú preparares tu corazón, y extendieres a él tus manos:
 \v 14 Si alguna iniquidad \add está\add* en tu mano, y la echares de ti, y no consintieres que en tus habitaciones more maldad:
@@ -289,18 +289,18 @@
 \v 10 Y que en su mano está el alma de todo viviente, el espíritu de toda carne humana?
 \v 11 Ciertamente el oído prueba las palabras, y el paladar gusta las viandas.
 \v 12 En los viejos \add está\add* la ciencia, y en longura de días la inteligencia.
-\v 13 Con el \add está\add* la sabiduría y la fortaleza, suyo \add es\add* el consejo y la inteligencia.
-\v 14 He aquí, el derribará, y no será edificado: encerrará al hombre, y no habrá quien le abra.
+\v 13 Con él \add está\add* la sabiduría y la fortaleza, suyo \add es\add* el consejo y la inteligencia.
+\v 14 He aquí, él derribará, y no será edificado: encerrará al hombre, y no habrá quien le abra.
 \v 15 He aquí, él detendrá las aguas, y se secarán: él las enviará, y destruirán la tierra.
 \v 16 Con él \add está\add* la fortaleza y la existencia: suyo es el que yerra, y el que hace errar.
-\v 17 El hace andar a los consejeros desnudos, y hace enloquecer a los jueces.
-\v 18 El suelta la atadura de los tiranos, y les ata la cinta en sus lomos.
-\v 19 El lleva despojados a los príncipes, y él trastorna a los valientes.
-\v 20 El quita la habla a los que dicen verdad, y el toma el consejo a los ancianos.
-\v 21 El derrama menosprecio sobre los príncipes, y enflaquece la fuerza de los esforzados.
-\v 22 El descubre las profundidades de las tinieblas, y saca a luz la sombra de muerte.
-\v 23 El multiplica las gentes, y él las pierde: él esparce las gentes, y las torna a recoger.
-\v 24 El quita el seso de las cabezas del pueblo de la tierra, y los hace que se pierdan vagueando sin camino:
+\v 17 Él hace andar a los consejeros desnudos, y hace enloquecer a los jueces.
+\v 18 Él suelta la atadura de los tiranos, y les ata la cinta en sus lomos.
+\v 19 Él lleva despojados a los príncipes, y él trastorna a los valientes.
+\v 20 Él quita la habla a los que dicen verdad, y él toma el consejo a los ancianos.
+\v 21 Él derrama menosprecio sobre los príncipes, y enflaquece la fuerza de los esforzados.
+\v 22 Él descubre las profundidades de las tinieblas, y saca a luz la sombra de muerte.
+\v 23 Él multiplica las gentes, y él las pierde: él esparce las gentes, y las torna a recoger.
+\v 24 Él quita el seso de las cabezas del pueblo de la tierra, y los hace que se pierdan vagueando sin camino:
 \v 25 Que palpen las tinieblas, y no la luz: y los hace errar como borrachos.
 \c 13
 \v 1 He aquí que todas estas cosas han visto mis ojos, y oído y entendido para sí mis oídos.
@@ -312,7 +312,7 @@
 \v 7 ¿Habéis de hablar iniquidad por Dios? ¿habéis de hablar por él engaño?
 \v 8 ¿Habéis vosotros de hacerle honra? ¿habéis de pleitear vosotros por Dios?
 \v 9 ¿Sería bueno que él os escudriñase? ¿Burlaros heis con él, como quien se burla con algún hombre?
-\v 10 El arguyendo os argüirá duramente, si en lo secreto le hicieseis tal honra.
+\v 10 Él arguyendo os argüirá duramente, si en lo secreto le hicieseis tal honra.
 \v 11 Ciertamente su alteza os había de espantar, y su pavor había de caer sobre vosotros.
 \v 12 Vuestras memorias serán comparadas a la ceniza, y vuestros cuerpos como cuerpos de lodo.
 \v 13 ¶ Escuchádme, y hablaré yo, y véngame después lo que viniere.
@@ -380,14 +380,14 @@
 \v 23 Desasosegado \add viene\add* a comer siempre, \add porque\add* sabe que le está aparejado día de tinieblas.
 \v 24 Tribulación y angustia le asombrará, y se esforzará contra él, como un rey aparejado para la batalla.
 \v 25 Porque él extendió su mano contra Dios, y contra el Todopoderoso se esforzó.
-\v 26 El le encontrará en la cerviz, en lo grueso de los hombros de sus escudos.
+\v 26 Él le encontrará en la cerviz, en lo grueso de los hombros de sus escudos.
 \v 27 Porque cubrió su rostro con su gordura: e hizo arrugas sobre los ijares.
 \v 28 Y habitó las ciudades asoladas, las casas inhabitadas, que estaban puestas en montones.
 \v 29 No enriquecerá, ni será firme su potencia, ni extenderá por la tierra su hermosura.
 \v 30 No se escapará de las tinieblas: la llama secará su renuevo, y con el aliento de su boca perecerá.
 \v 31 No será afirmado: en vanidad yerra: por lo cual en vanidad será trocado.
 \v 32 Él será cortado antes de su tiempo, y sus renuevos no reverdecerán.
-\v 33 El perderá su agraz, como la vid; y como la oliva derramará su flor.
+\v 33 Él perderá su agraz, como la vid; y como la oliva derramará su flor.
 \v 34 Porque la compañía del hipócrita será asolada: y fuego consumirá las tiendas de cohecho.
 \v 35 Concibieron dolor, y parieron iniquidad: y las entrañas de ellos meditan engaño.
 \c 16
@@ -419,7 +419,7 @@
 \v 3 Pon ahora, y dáme fianzas contigo: ¿quién tocará ahora mi mano?
 \v 4 Porque el corazón de ellos has escondido de entendimiento: por tanto no \add los\add* ensalzarás.
 \v 5 El que denuncia lisonjas a \add sus\add* prójimos, los ojos de sus hijos desfallezcan.
-\v 6 El me ha puesto por parábola de pueblos, y delante \add de ellos\add* he sido tamboril.
+\v 6 Él me ha puesto por parábola de pueblos, y delante \add de ellos\add* he sido tamboril.
 \v 7 Y mis ojos se oscurecieron de desabrimiento, y todos mis pensamientos \add han sido\add* como sombra.
 \v 8 Los rectos se maravillarán de esto, y el inocente se despertará contra el hipócrita.
 \v 9 Mas el justo retendrá su carrera; y el limpio de manos aumentará la fuerza.
@@ -638,10 +638,10 @@
 \v 6 El sepulcro es descubierto delante de él, y el infierno no tiene cobertura.
 \v 7 Extiende al aquilón sobre vacío: cuelga la tierra sobre nada.
 \v 8 Las aguas ata en sus nubes, y las nubes no se rompen debajo de ellas.
-\v 9 El aprieta la faz de su trono, y extiende sobre él su nube.
-\v 10 El cercó con término la superficie de las aguas hasta que se acabe la luz y las tinieblas.
+\v 9 Él aprieta la faz de su trono, y extiende sobre él su nube.
+\v 10 Él cercó con término la superficie de las aguas hasta que se acabe la luz y las tinieblas.
 \v 11 Las columnas del cielo tiemblan, y se espantan de su reprensión.
-\v 12 El rompe la mar con su potencia, y con su entendimiento hiere [su] hinchazón.
+\v 12 Él rompe la mar con su potencia, y con su entendimiento hiere [su] hinchazón.
 \v 13 Su Espíritu adornó los cielos: su mano crió la serpiente rolliza.
 \v 14 He aquí, estas son partes de sus caminos: ¿y cuán poco \add es\add* lo que habemos oído de él? porque el estruendo de sus fortalezas ¿quién lo entenderá?
 \c 27
@@ -786,7 +786,7 @@
 \v 28 Esto también fuera maldad probada, porque negaría al Dios soberano.
 \v 29 Si me alegré en el quebrantamiento del que me aborrecía, y me regocijé, cuando le halló el mal.
 \v 30 Que ni aun entregué al pecado mi paladar, pidiendo maldición para su alma,
-\v 31 Cuando mis domésticos decían: ¿quién nos diese de su carne? nunca nos hartaríamos.
+\v 31 Cuando mis domésticos decían: ¿Quién nos diese de su carne? nunca nos hartaríamos.
 \v 32 El extranjero no tenía fuera la noche: mis puertas abría al caminante.
 \v 33 Si encubrí como los hombres mis prevaricaciones, escondiendo en mi escondrijo mi iniquidad;
 \v 34 Porque quebrantaba a la gran multitud, y el menosprecio de las familias me atemorizó, y callé, y no salí de \add mi\add* puerta;
@@ -917,7 +917,7 @@
 \v 6 No dará vida al impío; y a los afligidos dará su derecho.
 \v 7 No quitará sus ojos del justo: mas con los reyes los pondrá también en trono para siempre, y serán ensalzados.
 \v 8 Y si estuvieren presos en grillos, y cautivos en las cuerdas de aflicción,
-\v 9 El les anunciará la obra de ellos, y que sus rebeliones prevalecieron.
+\v 9 Él les anunciará la obra de ellos, y que sus rebeliones prevalecieron.
 \v 10 Y despierta el oído de ellos para castigo, y dice que se conviertan de la iniquidad.
 \v 11 Si oyeren, y sirvieren, acabarán sus días en bien, y sus años en deleites.
 \v 12 Mas si no oyeren, serán pasados a cuchillo: y perecerán sin sabiduría.
@@ -1064,7 +1064,7 @@
 \v 21 Debajo de las sombras se echará, en lo oculto de las cañas, y de los lugares húmedos.
 \v 22 Los \add árboles\add* sombríos le cubren con su sombra; los sauces del arroyo le cercan.
 \v 23 He aquí que él robará el río que no corra; y confíase que el Jordán pasará por su boca.
-\v 24 El le tomará por sus ojos en los tropezaderos, y le horadará la nariz.
+\v 24 Él le tomará por sus ojos en los tropezaderos, y le horadará la nariz.
 \c 41
 \v 1 ¿Sacarás tú al Leviatán con el anzuelo; y con la cuerda que le echares en su lengua?
 \v 2 ¿Pondrás \add tú\add* garfio en sus narices; y horadarás tú con espina su quijada?

--- a/USFM/19_PSA_RV1865.usfm
+++ b/USFM/19_PSA_RV1865.usfm
@@ -153,12 +153,12 @@
 \v 6 Lloverá sobre los malos lazos, fuego y azufre; y viento de torbellinos \add será\add* la parte de su vaso.
 \v 7 Porque el justo Jehová amó las justicias: al recto mirará su rostro.
 \c 12
-\d Al Vencedor sobre Seminit. Salmo de David
+\d Al Vencedor sobre Seminit. Salmo de David.
 \v 1 Salva, o! Jehová, porque se acabaron los misericordiosos: porque se han acabado los fieles de \add entre\add* los hijos de los hombres.
 \v 2 Mentira habla cada uno con su prójimo \add con\add* labios lisonjeros: con doblez de corazón, hablan.
 \v 3 Tale Jehová todos los labios lisonjeros: la lengua que habla grandezas.
 \v 4 Que dijeron: Por nuestra lengua prevaleceremos: nuestros labios \add están\add* con nosotros, ¿quién nos \add es\add* Señor?
-\v 5 ¶ Por la opresión de los pobres, por el gemido de los menesterosos, ahora me levantaré, dice Jehová: \add yo\add* pondré en salvo al que \add el\add* enlaza.
+\v 5 ¶ Por la opresión de los pobres, por el gemido de los menesterosos, ahora me levantaré, dice Jehová: \add yo\add* pondré en salvo al que \add él\add* enlaza.
 \v 6 Las palabras de Jehová, palabras limpias: plata refinada en horno de tierra: colada siete veces.
 \v 7 Tú, Jehová, los guardarás: guárdalos para siempre de aquesta generación.
 \v 8 Cercando andan los malos: entretanto las vilezas de los hijos de los hombres son exaltadas.
@@ -500,7 +500,7 @@
 \v 4 Porque derecha \add es\add* la palabra de Jehová: y toda su obra con verdad.
 \v 5 Él ama justicia y juicio: de la misericordia de Jehová \add está\add* llena la tierra.
 \v 6 Con la palabra de Jehová fueron hechos los cielos: y con el espíritu de su boca todo el ejército de ellos.
-\v 7 El junta, como en un montón, las aguas de la mar: él pone por tesoros los abismos.
+\v 7 Él junta, como en un montón, las aguas de la mar: él pone por tesoros los abismos.
 \v 8 Teman a Jehová toda la tierra: teman de él todos los habitadores del mundo.
 \v 9 Porque él dijo, y fue; él mandó y estuvo.
 \v 10 Jehová hace anular el consejo de las gentes, y él hace anular las maquinaciones de los pueblos.
@@ -508,7 +508,7 @@
 \v 12 Bienaventurada la gente a quien Jehová es su Dios: el pueblo a quien escogió por heredad para sí.
 \v 13 Desde los cielos miró Jehová; vio a todos los hijos de Adam.
 \v 14 Desde la morada de su asiento miró sobre todos los moradores de la tierra.
-\v 15 El formó el corazón de todos ellos; él entiende todas sus obras.
+\v 15 Él formó el corazón de todos ellos; él entiende todas sus obras.
 \v 16 El rey no es salvo con la multitud del ejército; el valiente no escapa con la mucha fuerza.
 \v 17 Vanidad es el caballo para la salud; con la multitud de su fuerza no escapa.
 \v 18 He aquí, el ojo de Jehová sobre los que le temen; sobre los que esperan su misericordia;
@@ -783,7 +783,7 @@
 \v 1 Todos los pueblos batid las manos: clamád a Dios con voz de alegría.
 \v 2 Porque Jehová \add es\add* sublime y temeroso: Rey grande sobre toda la tierra.
 \v 3 \add Él\add* someterá a los pueblos debajo de nosotros, y a las naciones debajo de nuestros pies.
-\v 4 \add El\add* nos eligirá nuestras heredades; la hermosura de Jacob, al cual amó. Selah.
+\v 4 \add Él\add* nos eligirá nuestras heredades; la hermosura de Jacob, al cual amó. Selah.
 \v 5 Subió Dios con júbilo, Jehová con voz de trompeta.
 \v 6 Cantád a Dios, cantád; cantád a nuestro Rey, cantád.
 \v 7 Porque el Rey de toda la tierra \add es\add* Dios: cantád entendiendo.
@@ -825,7 +825,7 @@
 \v 16 No temas cuando se enriquece alguno: cuando aumenta la gloria de su casa.
 \v 17 Porque en su muerte no tomará nada: ni su gloria descenderá en pos de él.
 \v 18 Porque mientras viviere, será su vida bendita: y tú serás loado cuando fueres bueno.
-\v 19 \add El\add* entrará a la generación de sus padres: para siempre no verán luz.
+\v 19 \add Él\add* entrará a la generación de sus padres: para siempre no verán luz.
 \v 20 El hombre en honra \add que\add* no entiende, semejante es a las bestias \add que\add* mueren.
 \c 50
 \d Salmo: a Asaf.
@@ -898,7 +898,7 @@
 \v 2 O! Dios, oye mi oración, escucha las razones de mi boca.
 \v 3 Porque extraños se han levantado contra mí, y fuertes han buscado a mi alma: no han puesto a Dios delante de si. Selah.
 \v 4 He aquí, Dios \add es\add* el que me ayuda; el Señor \add es\add* con los que sustentan mi vida.
-\v 5 \add El\add* volverá el mal a mis enemigos; córtalos por tu verdad.
+\v 5 \add Él\add* volverá el mal a mis enemigos; córtalos por tu verdad.
 \v 6 Voluntariamente sacrificaré a ti; alabaré tu nombre, o! Jehová, porque \add es\add* bueno.
 \v 7 Porque me ha escapado de toda angustia, y en mis enemigos vieron mis ojos \add la venganza\add*.
 \c 55
@@ -945,7 +945,7 @@
 \d Al Vencedor: No destruyas: Mictam de David, cuando huía delante de Saul, en la cueva.
 \v 1 Ten misericordia de mí, o! Dios, ten misericordia de mí; porque en ti ha confiado mi alma, y en la sombra de tus alas me ampararé, hasta que pasen los quebrantamientos.
 \v 2 Clamaré al Dios Altísimo, al Dios que me galardona.
-\v 3 El enviará desde los cielos, y me salvará de la afrenta de él que me traga. Selah. Dios enviará su misericordia y su verdad.
+\v 3 Él enviará desde los cielos, y me salvará de la afrenta de el que me traga. Selah. Dios enviará su misericordia y su verdad.
 \v 4 Mi vida \add está\add* entre leones: estoy echado entre hijos de hombres que echan llamas: sus dientes \add son\add* lanza y saetas, y su lengua espada aguda.
 \v 5 Ensálzate sobre los cielos, o! Dios: sobre toda la tierra \add se ensalce\add* tu gloria.
 \v 6 Red han compuesto a mis pasos, mi alma se ha abatido: hoyo han cavado delante de mí, caigan en medio de él. Selah.
@@ -1008,16 +1008,16 @@
 \v 4 \add Yo\add* habitaré en tu tabernáculo para siempre; estaré seguro en el escondedero de tus alas.
 \v 5 Porque tú, o! Dios, has oído mis votos; has dado heredad a los que temen tu nombre.
 \v 6 Días sobre días añadirás al rey: sus años \add serán\add* como generación y generación.
-\v 7 \add El\add* estará para siempre delante de Dios; misericordia y verdad apercibe \add que\add* le conserven.
+\v 7 \add Él\add* estará para siempre delante de Dios; misericordia y verdad apercibe \add que\add* le conserven.
 \v 8 Así cantaré tu nombre para siempre, pagando mis votos cada día.
 \c 62
 \d Al Vencedor: a Iditún. Salmo de David.
 \v 1 En Dios solamente \add está\add* callada mi alma; de él \add es\add* mi salud.
-\v 2 El solamente \add es\add* mi fuerte y mi salud: mi refugio, no resbalaré mucho.
+\v 2 Él solamente \add es\add* mi fuerte y mi salud: mi refugio, no resbalaré mucho.
 \v 3 ¿Hasta cuándo maquinaréis contra un hombre? seréis muertos todos vosotros; como pared acostada \add seréis, como\add* vallado rempujado.
 \v 4 Solamente consultan para arrojarle de su grandeza: aman la mentira: con su boca bendicen, mas en sus entrañas maldicen. Selah.
 \v 5 En Dios solamente repósate, o! alma mía; porque de él \add es\add* mi esperanza.
-\v 6 El solamente \add es\add* mi fuerte y mi salud: mi refugio, no resbalaré.
+\v 6 Él solamente \add es\add* mi fuerte y mi salud: mi refugio, no resbalaré.
 \v 7 Sobre Dios \add es\add* mi salud y mi gloria: peña de mi fortaleza: mi refugio \add es\add* en Dios.
 \v 8 ¶ Esperád en él en todo tiempo, o! pueblos: derramád delante de él vuestro corazón: Dios \add es\add* nuestro amparo. Selah.
 \v 9 Solamente vanidad \add son\add* los hijos de Adam, mentira los hijos del varón, pesándolos a todos juntos en balanzas, \add serán\add* menos que la vanidad.
@@ -1072,7 +1072,7 @@
 \v 4 Toda la tierra te adorará, y cantarán a ti: cantarán a tu nombre. Selah.
 \v 5 Veníd, y ved las obras de Dios: terrible en hechos sobre los hijos de los hombres.
 \v 6 Volvió la mar en seco: por el río pasaron a pie; allí nos alegramos en él.
-\v 7 El se enseñorea con su fortaleza para siempre: sus ojos atalayan sobre las naciones: los rebeldes no serán ellos ensalzados. Selah.
+\v 7 Él se enseñorea con su fortaleza para siempre: sus ojos atalayan sobre las naciones: los rebeldes no serán ellos ensalzados. Selah.
 \v 8 Bendecíd pueblos a nuestro Dios: y hacéd oír la voz de su loor.
 \v 9 El que puso nuestra alma en vida: y no permitió que resbalasen nuestros pies.
 \v 10 Porque \add tú\add* nos probaste, o! Dios: afinástenos, como se afina la plata.
@@ -1205,7 +1205,7 @@
 \c 72
 \d \add Salmo\add* para Salomón.
 \v 1 O! Dios, da tus juicios al rey, y tu justicia al hijo del rey.
-\v 2 El juzgará a tu pueblo con justicia: y a tus afligidos con juicio.
+\v 2 Él juzgará a tu pueblo con justicia: y a tus afligidos con juicio.
 \v 3 Los montes llevarán paz al pueblo: y los collados justicia.
 \v 4 Juzgará a los afligidos del pueblo: Salvará a los hijos del menesteroso, y quebrantará al violento.
 \v 5 Temerte han con el sol, y antes de la luna: por generación de generaciones.
@@ -1589,7 +1589,7 @@
 \v 23 Mas \add yo\add* quebrantaré delante de él a sus enemigos: y heriré a sus aborrecedores.
 \v 24 Y mi verdad y mi misericordia \add serán\add* con él; y en mi nombre será ensalzado su cuerno.
 \v 25 Y pondré su mano en la mar, y en los ríos su diestra.
-\v 26 El me llamará: Mi padre \add eres\add* tú, mi Dios, la roca de mi salud.
+\v 26 Él me llamará: Mi padre \add eres\add* tú, mi Dios, la roca de mi salud.
 \v 27 Yo también le pondré \add por\add* primogénito; alto sobre los reyes de la tierra.
 \v 28 Para siempre le conservaré mi misericordia; y mi alianza será firme con él.
 \v 29 Y pondré su simiente para siempre; y su trono como los días de los cielos.
@@ -1800,7 +1800,7 @@
 \v 20 Para oír el gemido de los presos: para soltar a los sentenciados a muerte:
 \v 21 Porque publiquen en Sión el nombre de Jehová: y su alabanza en Jerusalem,
 \v 22 Cuando los pueblos se congregaren en uno, y los reinos para servir a Jehová.
-\v 23 \add El\add* afligió mi fuerza en el camino, acortó mis días.
+\v 23 \add Él\add* afligió mi fuerza en el camino, acortó mis días.
 \v 24 Dije: Dios mío, no me cortes en el medio de mis días; por generación de generaciones \add son\add* tus años.
 \v 25 Tú fundaste la tierra antiguamente, y los cielos son obra de tus manos.
 \v 26 Ellos perecerán, y tú permanecerás; y todos ellos como \add un\add* vestido se envejecerán, como \add una\add* ropa de vestir los mudarás, y serán mudados:
@@ -1835,7 +1835,7 @@
 \v 2 Que se cubre de luz como de vestidura, que extiende los cielos como \add una\add* cortina;
 \v 3 Que entabla con las aguas sus doblados, el que pone a las nubes por su carro, el que anda sobre las alas del viento.
 \v 4 El que hace a sus ángeles espíritus, sus ministros al fuego flameante.
-\v 5 ¶ El fundó la tierra sobre sus basas, no se moverá por ningún siglo.
+\v 5 ¶ Él fundó la tierra sobre sus basas, no se moverá por ningún siglo.
 \v 6 Con el abismo, como con vestido, la cubriste: sobre los montes estaban las aguas.
 \v 7 De tu reprensión huyeron; por el sonido de tu trueno se apresuraron.
 \v 8 Subieron los montes, descendieron los valles a este lugar, que tú les fundaste.
@@ -1873,7 +1873,7 @@
 \v 4 Buscád a Jehová, y a su fortaleza: buscád su rostro siempre.
 \v 5 Acordáos de sus maravillas, que hizo: de sus prodigios, y de los juicios de su boca,
 \v 6 Simiente de Abraham su siervo: hijos de Jacob sus escogidos.
-\v 7 El \add es\add* Jehová nuestro Dios: en toda la tierra \add están\add* sus juicios.
+\v 7 Él \add es\add* Jehová nuestro Dios: en toda la tierra \add están\add* sus juicios.
 \v 8 Acordóse para siempre de su alianza: de la palabra \add que\add* mandó para mil generaciones:
 \v 9 La cual concertó con Abraham, y de su juramento a Isaac.
 \v 10 Y establecióla a Jacob por decreto, a Israel por concierto eterno,
@@ -1987,7 +1987,7 @@
 \v 22 Y sacrifiquen sacrificios de alabanza; y enarren sus obras con jubilación.
 \v 23 ¶ Los que descendieron a la mar en navíos: y contratan en las muchas aguas;
 \v 24 Ellos han visto las obras de Jehová, y sus maravillas en el \add mar\add* profundo.
-\v 25 El dijo, y salió el viento de la tempestad, que levanta sus ondas:
+\v 25 Él dijo, y salió el viento de la tempestad, que levanta sus ondas:
 \v 26 Suben a los cielos, descienden a los abismos: sus almas se derriten con el mal.
 \v 27 Tiemblan, y titubean como borrachos; y toda su ciencia es perdida.
 \v 28 Y claman a Jehová en su angustia; y escápalos de sus aflicciones.
@@ -2002,7 +2002,7 @@
 \v 37 Y siembran campos, y plantan viñas; y hacen fruto de renta:
 \v 38 Y bendícelos, y \add se\add* multiplican en gran manera: y no disminuye sus bestias.
 \v 39 Y \add después\add* son menoscabados, y abatidos de tiranía, de males, y de congojas.
-\v 40 ¶ El derrama menosprecio sobre los príncipes: y les hace andar errantes, vagabundos, sin camino.
+\v 40 ¶ Él derrama menosprecio sobre los príncipes: y les hace andar errantes, vagabundos, sin camino.
 \v 41 Y levanta al pobre de la pobreza; y vuelve las familias como ovejas.
 \v 42 Vean los rectos, y alégrense; y toda maldad cierre su boca.
 \v 43 ¿Quién es sabio, y guardará estas cosas; y entenderá las misericordias de Jehová?
@@ -2743,7 +2743,7 @@
 \v 11 Los reyes de la tierra, y todos los pueblos: los príncipes, y todos los jueces de la tierra.
 \v 12 Los mancebos, y también las doncellas: los viejos con los mozos.
 \v 13 Alaben el nombre de Jehová; porque su nombre de él solo \add es\add* ensalzado: su gloria \add es\add* sobre tierra y cielos.
-\v 14 \add El\add* ensalzó el cuerno de su pueblo: aláben\add le\add* todos sus misericordiosos: los hijos de Israel, el pueblo a él cercano. Alelu-\nd Jah\nd*.
+\v 14 \add Él\add* ensalzó el cuerno de su pueblo: aláben\add le\add* todos sus misericordiosos: los hijos de Israel, el pueblo a él cercano. Alelu-\nd Jah\nd*.
 \c 149
 \d Alelu-\nd Jah\nd*.
 \v 1 Cantád a Jehová canción nueva: su alabanza \add sea\add* en la congregación de los misericordiosos.

--- a/USFM/20_PRO_RV1865.usfm
+++ b/USFM/20_PRO_RV1865.usfm
@@ -47,7 +47,7 @@
 \v 4 Si como a la plata, la buscares, y como a tesoros la escudriñares:
 \v 5 Entonces entenderás el temor de Jehová; y hallarás el conocimiento de Dios.
 \v 6 Porque Jehová da la sabiduría; y de su boca \add viene\add* el conocimiento, y la inteligencia.
-\v 7 El guarda el ser a los rectos: \add es\add* escudo a los que caminan perfectamente,
+\v 7 Él guarda el ser a los rectos: \add es\add* escudo a los que caminan perfectamente,
 \v 8 Guardando las veredas del juicio; y el camino de sus misericordiosos guardará.
 \v 9 Entonces entenderás justicia, juicio, y equidad, y todo buen camino.
 \v 10 ¶ Cuando la sabiduría entrare en tu corazón, y la ciencia fuere dulce a tu alma;
@@ -708,7 +708,7 @@
 \v 32 A su fin morderá como serpiente; y como basilisco dará dolor.
 \v 33 Tus ojos mirarán las extrañas; y tu corazón hablará perversidades.
 \v 34 Y serás como el que yace en medio de la mar; y como el que yace en cabo del mastelero.
-\v 35 \add Y dirás\add* hiriéronme, mas no me dolió: azotáronme, mas no lo sentí: cuando despertaré, aun lo tornaré a buscar.
+\v 35 \add Y dirás\add* hiriéronme, mas no me dolió: azotáronme, mas no lo sentí: cuando despertare, aun lo tornaré a buscar.
 \c 24
 \v 1 No tengas envidia de los hombres malos: ni desees estar con ellos.
 \v 2 Porque su corazón piensa en robar; e iniquidad hablan sus labios.

--- a/USFM/23_ISA_RV1865.usfm
+++ b/USFM/23_ISA_RV1865.usfm
@@ -68,7 +68,7 @@
 \v 4 Y ponerles he mozos por príncipes, y muchachos serán sus señores.
 \v 5 Y el pueblo hará violencia los unos a los otros, cada hombre contra su vecino: el mozo se levantará contra el viejo, y el plebeyo contra el noble.
 \v 6 Cuando alguno trabare de su hermano de la familia de su padre, y le dijere: ¿Qué vestir tienes? Tú serás nuestro príncipe: sea en tu mano esta perdición.
-\v 7 El jurará aquel día, diciendo: No tomaré ese cuidado; porque en mi casa ni hay pan, ni que vestir: no me hagáis príncipe del pueblo.
+\v 7 Él jurará aquel día, diciendo: No tomaré ese cuidado; porque en mi casa ni hay pan, ni que vestir: no me hagáis príncipe del pueblo.
 \v 8 Cierto arruinado se ha Jerusalem, y caído ha Judá; porque la lengua de ellos y sus obras \add han sido\add* contra Jehová, para irritar los ojos de su majestad.
 \v 9 ¶ La prueba del rostro de ellos los convencerá: que como Sodoma predicaron su pecado, no \add lo\add* disimularon: ¡ay de su vida! porque allegaron mal para sí.
 \v 10 Decíd: Al justo bien \add le irá\add*; porque comerá de los frutos de sus manos.
@@ -833,14 +833,14 @@
 \v 19 El artífice apareja la imagen de talla: el platero la extiende el oro, y el platero le \add funde\add* cadenas de plata.
 \v 20 El pobre escoge para ofrecerle madera que no se corrompa: búscase un maestro sabio, que le haga \add una\add* imagen de talla \add de manera\add* que no se mueva.
 \v 21 ¿No sabéis? ¿No habéis oído? ¿Nunca os lo han dicho desde el principio? ¿No habéis sido enseñados desde que la tierra se fundó?
-\v 22 El está asentado sobre el globo de la tierra, cuyos moradores \add le\add* son como langostas: él extiende los cielos como \add una\add* cortina, tiéndelos como \add una\add* tienda para morar.
-\v 23 El torna en nada los poderosos; y a los que gobiernan la tierra, hace como que no hubieran sido.
+\v 22 Él está asentado sobre el globo de la tierra, cuyos moradores \add le\add* son como langostas: él extiende los cielos como \add una\add* cortina, tiéndelos como \add una\add* tienda para morar.
+\v 23 Él torna en nada los poderosos; y a los que gobiernan la tierra, hace como que no hubieran sido.
 \v 24 Como si nunca fueran plantados, como si nunca fueran sembrados, como si nunca su tronco hubiera tenido raíz en la tierra; y aun soplando en ellos se secan, y el torbellino los lleva como hojarascas.
 \v 25 ¿Y a qué me haréis semejante para que sea semejante, dice el Santo?
 \v 26 Levantád en alto vuestros ojos y mirád quien creó estas cosas: él saca por cuenta su ejército: a todas llama por sus nombres: ninguna faltará por la multitud de sus fuerzas, y por la fortaleza de la fuerza.
 \v 27 ¿Por qué dices Jacob, y hablas Israel: Mi camino es escondido de Jehová, y de mi Dios pasó mi juicio?
 \v 28 ¿No has sabido? ¿No has oído, que el Dios del siglo es Jehová, el cual creó los términos de la tierra? No se trabaja, ni se fatiga con cansancio; y su entendimiento no hay quien lo alcance.
-\v 29 El da esfuerzo al cansado, y multiplica las fuerzas al que no tiene ningunas.
+\v 29 Él da esfuerzo al cansado, y multiplica las fuerzas al que no tiene ningunas.
 \v 30 Los mancebos se fatigan, y se cansan: los mozos cayendo caen:
 \v 31 Mas los que esperan a Jehová tendrán nuevas fuerzas, levantarán las alas como águilas, correrán y no se cansarán, caminarán y no se fatigarán.
 \c 41

--- a/USFM/24_JER_RV1865.usfm
+++ b/USFM/24_JER_RV1865.usfm
@@ -267,7 +267,7 @@
 \v 21 Porque la muerte ha subido por nuestras ventanas, ha entrado en nuestros palacios para talar los niños de las calles, los mancebos de las plazas.
 \v 22 Habla: Así dijo Jehová: Los cuerpos de los hombres muertos caerán sobre la haz del campo, como estiércol, y como el manojo tras el segador, que no \add hay\add* quien lo coja.
 \v 23 ¶ Así dijo Jehová: No se alabe el sabio en su sabiduría, ni se alabe el valiente en su valentía, ni se alabe el rico en sus riquezas:
-\v 24 Mas alábese en esto el que se hubiere de alabar, en entenderme y conocerme, que \sc yo soy\sc* \nd Jehová\nd*, \sc que hago misericordia, juicio, y justicia en la tierra\sc*; porque estas cosas quiero, dijo Jehová.
+\v 24 Mas alábese en esto el que se hubiere de alabar, en entenderme y conocerme, que \sc yo soy Jehová, que hago misericordia, juicio, y justicia en la tierra\sc*; porque estas cosas quiero, dijo Jehová.
 \v 25 He aquí que vienen días, dijo Jehová, y visitaré sobre todo circuncidado, y sobre todo incircunciso:
 \v 26 A Egipto, y a Judá, y a Edom, y a los hijos de Ammón y de Moab, y a todos los arrinconados en el postrer rincón, que moran en el desierto; porque todas las naciones tienen prepucio, y toda la casa de Israel tiene prepucio en el corazón.
 \c 10
@@ -405,7 +405,7 @@
 \v 13 Tus riquezas y tus tesoros daré a saco sin ningún precio, por todos tus pecados, y en todos tus términos:
 \v 14 Y hacerte he pasar a tus enemigos en tierra que no conoces; porque fuego es encendido en mi furor, y sobre vosotros arderá.
 \v 15 ¶ Tú, o! Jehová, lo sabes, acuérdate de mí, y visítame, y véngame de mis enemigos: no me tomes a \add tu cargo\add* en la paciencia de tu enojo: sepas que sufro vergüenza a causa de ti.
-\v 16 Halláronse tus palabras, y \add yo\add* las comí; y tu palabra me fue por gozo, y por alegría de mí corazón; porque tu nombre se llamó sobre mí, o! Jehová Dios de los ejércitos.
+\v 16 Halláronse tus palabras, y \add yo\add* las comí; y tu palabra me fue por gozo, y por alegría de mi corazón; porque tu nombre se llamó sobre mí, o! Jehová Dios de los ejércitos.
 \v 17 Nunca me asenté en compañía de burladores, ni me engreí a causa de tu profecía: solo me asenté, porque me henchiste de desabrimiento.
 \v 18 ¿Por qué fue perpetuo mi dolor, y mi herida desahuciada, no admitió cura? Eres conmigo como mentiroso, aguas que no son fieles.
 \v 19 Por tanto así dijo Jehová: Si te convirtieres, convertirte he, y delante de mí estarás; y si sacares lo precioso de lo vil, serás como mi boca. Conviértanse ellos a ti, y tú no te conviertas a ellos.
@@ -955,7 +955,7 @@
 \v 15 Y dijéronle: Siéntate ahora, y léelo en nuestros oídos. Y leyó Baruc en sus oídos.
 \v 16 Y fue que como oyeron todas aquellas palabras, cada uno se volvió espantado a su compañero, y dijeron a Baruc: sin duda contaremos al rey todas estas palabras.
 \v 17 Y preguntaron al mismo Baruc, diciendo: Cuéntanos ahora como escribiste de su boca todas estas palabras.
-\v 18 Y Baruc les dijo: El me dictaba de su boca todas estas palabras, y yo escribía con tinta en el libro.
+\v 18 Y Baruc les dijo: Él me dictaba de su boca todas estas palabras, y yo escribía con tinta en el libro.
 \v 19 Y los príncipes dijeron a Baruc: Vé, y escóndete tú, y Jeremías, y nadie sepa donde estáis.
 \v 20 Y entraron al rey al patio habiendo depositado el envoltorio en la cámara de Elisama escriba, y contaron en los oídos del rey todas estas palabras.
 \v 21 Y el rey envió a Jehudi que tomase el envoltorio, el cual lo tomó de la cámara de Elisama escriba, y leyó en él Jehudi en oídos del rey, y en oídos de todos los príncipes que estaban junto al rey.

--- a/USFM/26_EZK_RV1865.usfm
+++ b/USFM/26_EZK_RV1865.usfm
@@ -786,7 +786,7 @@
 \v 8 Y sabrán que yo \add soy\add* Jehová, cuando \add yo\add* pusiere fuego a Egipto, y fueren quebrantados todos sus ayudadores.
 \v 9 En aquel tiempo saldrán mensajeros de delante de mí en navíos a espantar a Etiopía la confiada; y tendrán espanto como en el día de Egipto; porque he aquí que viene.
 \v 10 Así dijo el Señor Jehová: Haré cesar la multitud de Egipto por mano de Nabucodonosor, rey de Babilonia:
-\v 11 El, y su pueblo con él, los más fuertes de las naciones serán traídos a destruir la tierra; y desvainarán sus espadas sobre Egipto; y henchirán la tierra de muertos.
+\v 11 Él, y su pueblo con él, los más fuertes de las naciones serán traídos a destruir la tierra; y desvainarán sus espadas sobre Egipto; y henchirán la tierra de muertos.
 \v 12 Y secaré los ríos, y entregaré la tierra en mano de malos, y destruiré la tierra y su plentitud por mano de extranjeros: yo Jehová he hablado.
 \v 13 Así dijo el Señor Jehová: Y destruiré las imágenes, y haré cesar los ídolos de Mémfis, y no habrá más capitán de la tierra de Egipto, y pondré temor en la tierra de Egipto.
 \v 14 Y asolaré a Patures, y pondré fuego a Tafnes, y haré juicios en No.
@@ -1253,7 +1253,7 @@
 \v 8 Y cuando el príncipe entrare, entrará por el camino del portal de la puerta, y por el \add mismo\add* camino saldrá.
 \v 9 Mas cuando el pueblo de la tierra entrare delante de Jehová en la fiestas, el que entrare por la puerta del norte, saldrá por la puerta del mediodía; y el que entrare por la puerta del mediodía, saldrá por la puerta del norte: no volverá por la puerta por donde entró, mas saldrá por \add la de\add* en frente de ella.
 \v 10 Y el príncipe, cuando ellos entraren, él entrará en medio de ellos: mas cuando ellos hubieren salido, él saldrá.
-\v 11 Y en las fiestas, y en las solemnidades, será el presente un efa \add de flor de harina\add* con \add cada\add* becerro, y \add otro\add* efa con cada carnero; y con los corderos, lo que le parciere; y un hin de aceite con \add cada\add* efa.
+\v 11 Y en las fiestas, y en las solemnidades, será el presente un efa \add de flor de harina\add* con \add cada\add* becerro, y \add otro\add* efa con cada carnero; y con los corderos, lo que le pareciere; y un hin de aceite con \add cada\add* efa.
 \v 12 Mas cuando el príncipe libremente hiciere holocausto, o pacíficos a Jehová, abrirle han la puerta, que mira al oriente, y hará su holocausto, y sus pacíficos, como hace en el día del sábado: después saldrá, y cerrarán la puerta después que saliere.
 \v 13 Y sacrificarás a Jehová cada día en holocausto un cordero de un año entero: cada mañana lo sacrificarás.
 \v 14 Y harás con el presente todas las mañanas, la sexta parte de un efa \add de flor de harina\add*, y la tercera parte de un hin de aceite para mezclar con la flor de harina: \add esto será\add* presente para Jehová continuamente por estatuto perpetuo.

--- a/USFM/27_DAN_RV1865.usfm
+++ b/USFM/27_DAN_RV1865.usfm
@@ -50,7 +50,7 @@
 \v 19 Entonces el misterio fue revelado a Daniel en visión de noche: por lo cual Daniel bendijo al Dios del cielo;
 \v 20 Y Daniel habló, y dijo: Sea bendito el nombre de Dios de siglo hasta siglo; porque suya es la sabiduría y la fortaleza.
 \v 21 Y él es el que muda los tiempos, y las oportunidades: quita reyes, y pone reyes: da la sabiduría a los sabios, y la ciencia a los entendidos:
-\v 22 El revela lo profundo y lo escondido: conoce lo que está en tinieblas, y la luz mora con él.
+\v 22 Él revela lo profundo y lo escondido: conoce lo que está en tinieblas, y la luz mora con él.
 \v 23 A ti, o! Dios de mis padres, te doy las gracias, y te alabo, que me diste sabiduría y fortaleza; y ahora me enseñaste lo que te pedimos, porque nos enseñaste el negocio del rey.
 \v 24 Después de esto Daniel entró a Arioc, al cual el rey había puesto para matar a los sabios de Babilonia: fue y díjole así: No mates los sabios de Babilonia: méteme delante del rey, que \add yo\add* mostraré al rey la declaración.
 \v 25 Entonces Arioc metió prestamente a Daniel delante del rey, y díjole así: Un varón de los trasportados de Judá he hallado, el cual declarará al rey la interpretación.

--- a/USFM/30_AMO_RV1865.usfm
+++ b/USFM/30_AMO_RV1865.usfm
@@ -151,7 +151,7 @@
 \v 3 Y si se escondieren en la cumbre del Carmelo, allí los buscaré, y los tomaré; y si se escondieren de delante de mis ojos en el profundo de la mar, allí mandaré a la culebra, y morderlos ha:
 \v 4 Y si fueren en cautiverio delante de sus enemigos, allí mandaré a la espada, y matarlos ha; y pondré sobre ellos mis ojos para mal, y no para bien.
 \v 5 El Señor Jehová de los ejércitos, que toca la tierra, y se derretirá, y llorarán todos los que en ella moran; y subirá toda como \add un río\add*, y será hundida como el río de Egipto.
-\v 6 El edificó en el cielo sus grados, y su conjunto fundó sobre la tierra: él llama las aguas de la mar, y las derrama sobre la haz de la tierra: Jehová \add es\add* su nombre.
+\v 6 Él edificó en el cielo sus grados, y su conjunto fundó sobre la tierra: él llama las aguas de la mar, y las derrama sobre la haz de la tierra: Jehová \add es\add* su nombre.
 \v 7 Hijos de Israel, ¿no me sois vosotros como hijos de Etiopes? dijo Jehová: ¿No hice yo subir a Israel de la tierra de Egipto, y a los Palestinos de Caftor, y a los Siros de Kir?
 \v 8 He aquí que los ojos del Señor Jehová \add están\add* contra el reino pecador; y yo le asolaré de la haz de la tierra: mas no destruiré del todo la casa de Jacob, dijo Jehová.
 \v 9 Porque he aquí que yo mandaré, y haré que la casa de Israel sea zarandada en todas las naciones, como se zaranda \add el grano\add* en un harnero, y no cae una chinica en la tierra.

--- a/USFM/32_JON_RV1865.usfm
+++ b/USFM/32_JON_RV1865.usfm
@@ -18,7 +18,7 @@
 \v 9 Y él les respondió: Hebreo soy, y a Jehová Dios de los cielos temo, que hizo la mar y la tierra.
 \v 10 Y aquellos hombres temieron de gran temor, y le dijeron: ¿Por qué hiciste esto? Porque ellos entendieron que huía de delante de Jehová; porque él se lo había declarado.
 \v 11 Y dijéronle: ¿Qué te haremos, para que la mar se nos quiete? porque la mar iba, y se embravecía.
-\v 12 El les respondió: Tomádme, y echádme a la mar, y la mar se os quietará; porque yo sé que por mí ha venido sobre vosotros esta grande tempestad.
+\v 12 Él les respondió: Tomádme, y echádme a la mar, y la mar se os quietará; porque yo sé que por mí ha venido sobre vosotros esta grande tempestad.
 \v 13 Y aquellos hombres trabajaron por tornar la nao a tierra, mas no pudieron; porque la mar iba y se embravecía sobre ellos.
 \v 14 Y clamaron a Jehová, y dijeron: Rogámoste ahora, Jehová, que no perezcamos nosotros por la vida de aqueste hombre, ni pongas sobre nosotros sangre inocente; porque tú, Jehová, has hecho como has querido.
 \v 15 Y tomaron a Jonás, y echáronle a la mar; y la mar se quietó de su ira.

--- a/USFM/33_MIC_RV1865.usfm
+++ b/USFM/33_MIC_RV1865.usfm
@@ -116,5 +116,5 @@
 \v 16 Las naciones verán, y avergonzarse han de todas sus valentías: pondrán la mano sobre \add su\add* boca, sus oídos se ensordecerán.
 \v 17 Lamerán el polvo como la culebra, como las serpientes de la tierra: temblarán en sus encerramientos: de Jehová nuestro Dios se despavorirán, y temerán de ti.
 \v 18 ¿Qué Dios como tú, que perdonas la maldad, y que pasas por la rebelión con el resto de su heredad? No retuvo para siempre su enojo, porque es amador de misericordia.
-\v 19 El tornará, él tendrá misericordia de nosotros, él sujetará nuestras iniquidades, y echará en los profundos de la mar todos nuestros pecados.
+\v 19 Él tornará, él tendrá misericordia de nosotros, él sujetará nuestras iniquidades, y echará en los profundos de la mar todos nuestros pecados.
 \v 20 Darás la verdad a Jacob, y a Abraham la misericordia, que juraste a nuestros padres desde tiempos antiguos.

--- a/USFM/34_NAM_RV1865.usfm
+++ b/USFM/34_NAM_RV1865.usfm
@@ -15,7 +15,7 @@
 \v 6 ¿Quién permanecerá delante de su ira? ¿y quién quedará en pie en el furor de su enojo? su ira se derrama como fuego, y las peñas se rompen por él.
 \v 7 Bueno \add es\add* Jehová para fortaleza en el día de la angustia; y que conoce a los que en él confían.
 \v 8 Y con inundación pasante hará consumación de su lugar; y tinieblas perseguirán sus enemigos.
-\v 9 ¿Qué pensáis contra Jehová? El hace consumación: no se levantará dos veces la tribulación.
+\v 9 ¿Qué pensáis contra Jehová? Él hace consumación: no se levantará dos veces la tribulación.
 \v 10 Porque como espinas entretejidas, cuando los borrachos se emborracharán, serán consumidos del fuego, como las estopas llenas de sequedad.
 \v 11 De ti salió el que pensó mal contra Jehová, consultor impío.
 \v 12 Así dijo Jehová: Aunque reposo tengan, y así muchos \add como son\add* así serán talados, y pasará; y si te afligí, no te afligiré más.
@@ -27,7 +27,7 @@
 \v 2 Porque Jehová tornará \add así\add* la gloria de Jacob como la gloria de Israel; porque los vaciaron vaciadores, e hirieron sus mugrones.
 \v 3 El escudo de sus valientes será bermejo, los varones de \add su\add* ejército vestidos de grana: el carro como fuego de hachas: el día que se aparejará, las hayas temblarán.
 \v 4 Los carros harán locuras en las plazas, discurrirán por las calles sus rostros como hachas: correrán como relámpagos.
-\v 5 El se acordará de sus valientes, andando tropezarán \add cuando\add* se apresuraren a su muro, y la cubierta se aparejare.
+\v 5 Él se acordará de sus valientes, andando tropezarán \add cuando\add* se apresuraren a su muro, y la cubierta se aparejare.
 \v 6 Las puertas de los ríos se abrirán, y el palacio será destruido.
 \v 7 Y la reina fue cautiva, mandarle han que suba; y sus criadas la llevarán, gimiendo como palomas, batiendo sus pechos.
 \v 8 Y fue Nínive de tiempo antiguo como estanque de aguas: mas ellos \add ahora\add* huyen: Parád, parád; y ninguno mira.

--- a/USFM/38_ZEC_RV1865.usfm
+++ b/USFM/38_ZEC_RV1865.usfm
@@ -60,7 +60,7 @@
 \v 4 Y hablé, y dije a aquel ángel que hablaba conmigo, diciendo: ¿Qué \add es\add* esto, señor mío?
 \v 5 Y aquel ángel que hablaba conmigo, respondió, y díjome: ¿No sabes que es esto? Y dije: No, señor mío.
 \v 6 Entonces respondió, y me habló, diciendo: Esta \add es\add* palabra de Jehová a Zorobabel en que se dice: No con ejército, ni con fuerza: mas con mi Espíritu, dijo Jehová de los ejércitos.
-\v 7 ¿Quién eres tú, o! gran monte, delante de Zorobabel? en llanura. El sacará la primera piedra con algazaras: Gracia, gracia a ella.
+\v 7 ¿Quién eres tú, o! gran monte, delante de Zorobabel? en llanura. Él sacará la primera piedra con algazaras: Gracia, gracia a ella.
 \v 8 Y fue palabra de Jehová a mí, diciendo:
 \v 9 Las manos de Zorobabel echarán el fundamento a esta casa, y sus manos la acabarán; y conocerás que Jehová de los ejércitos me envió a vosotros.
 \v 10 Porque los que menospreciaron el día de los pequeños \add principios\add*, se alegrarán, y verán la piedra de estaño en la mano de Zorobabel. Aquellas siete \add son\add* los ojos de Jehová extendidos por toda la tierra.
@@ -93,7 +93,7 @@
 \v 10 Toma \add de los que tornaron\add* del cautiverio, \add es a saber, de los del linaje\add* de Holdai, y de Tobías, y de Idaía, y vendrás tú en aquel día, y entrarás en casa de Josías, hijo de Sofonías, los cuales volvieron de Babilonia:
 \v 11 Y tomarás plata y oro, y harás coronas, y ponerlas has en la cabeza de Josué, hijo de Josedec, el gran sacerdote.
 \v 12 Y hablarle has, diciendo: Así habló Jehová de los ejércitos, diciendo: He aquí el varón cuyo nombre es RENUEVO, el cual retoñecerá de debajo de sí, y edificará el templo de Jehová.
-\v 13 El edificará el templo de Jehová, y él llevará gloria, y se asentará, y dominará en su trono; y será sacerdote en su trono; y consejo de paz será entre ambos a dos.
+\v 13 Él edificará el templo de Jehová, y él llevará gloria, y se asentará, y dominará en su trono; y será sacerdote en su trono; y consejo de paz será entre ambos a dos.
 \v 14 Y Helen, y Tobías, e Idaía, y Henel, hijo de Sofonías, tendrán coronas por memorial en el templo de Jehová.
 \v 15 Y los que están lejos vendrán, y edificarán en el templo de Jehová; y conoceréis que Jehová de los ejércitos me ha enviado a vosotros; y será, si oyendo oyereis la voz de Jehová vuestro Dios.
 \c 7
@@ -208,7 +208,7 @@
 \v 6 Y preguntarle han: ¿Qué heridas son estas \add que tienes\add* en tus manos? Y él responderá: Con estas fuí herido en casa de mis amigos.
 \v 7 ¶ ¡O espada! despiértate sobre el pastor, y sobre el hombre \add que fuere\add* mi compañero, dijo Jehová de los ejércitos: hiere al pastor, y derramarse han las ovejas; y tornaré mi mano sobre los chiquitos.
 \v 8 Y acontecerá en toda la tierra, dijo Jehová, que las dos partes serán taladas en ella, y se perderán; y la tercera quedará en ella.
-\v 9 Y meteré en el fuego la tercera parte, y fundirlos he como se funde la plata, y probarlos he como se prueba el oro: El invocará mi nombre, y yo lo oiré, y diré: Mi pueblo es; y él dirá: Jehová \add es\add* mi Dios.
+\v 9 Y meteré en el fuego la tercera parte, y fundirlos he como se funde la plata, y probarlos he como se prueba el oro: Él invocará mi nombre, y yo lo oiré, y diré: Mi pueblo es; y él dirá: Jehová \add es\add* mi Dios.
 \c 14
 \v 1 He aquí que el día de Jehová viene, y tus despojos serán repartidos en medio de ti.
 \v 2 Porque \add yo\add* reuniré todas las naciones en batalla contra Jerusalem; y la ciudad será tomada, y las casas serán saqueadas, y las mujeres serán forzadas; y la mitad de la ciudad irá en cautividad: mas el resto del pueblo no será talado de la ciudad.

--- a/USFM/41_MAT_RV1865.usfm
+++ b/USFM/41_MAT_RV1865.usfm
@@ -231,7 +231,7 @@
 \v 14 ¶ Y vino Jesús a casa de Pedro, y vio a su suegra echada en la cama, y con fiebre.
 \v 15 Y tocó su mano, y la fiebre la dejó; y ella se levantó, y les servía.
 \v 16 Y como fue ya tarde, trajeron a él muchos endemoniados, y echó \add de ellos\add* los demonios con \add su\add* palabra, y sanó todos los enfermos;
-\v 17 Para que se cumpliese lo que fue dicho por el profeta Isaías, que dijo: El tomó nuestras enfermedades, y llevó \add nuestras\add* dolencias.
+\v 17 Para que se cumpliese lo que fue dicho por el profeta Isaías, que dijo: Él tomó nuestras enfermedades, y llevó \add nuestras\add* dolencias.
 \v 18 ¶ Y viendo Jesús grandes multitudes al rededor de sí, mandó que se fuesen a la otra parte \add del lago\add*.
 \v 19 Y llegóse un escriba, y díjole: Maestro, seguirte he donde quiera que fueres.
 \v 20 Y Jesús le dijo: Las zorras tienen cavernas, y las aves del cielo nidos; mas el Hijo del hombre no tiene donde recostar \add su\add* cabeza.
@@ -696,7 +696,7 @@
 \v 20 Entonces se llegó a él la madre de los hijos de Zebedeo con sus hijos, adorando, y pidiéndole algo.
 \v 21 Y él le dijo: ¿Qué quieres? \add Ella\add* le dijo: Di que se asienten estos dos hijos míos, el uno a tu mano derecha, y el otro a tu izquierda, en tu reino.
 \v 22 Entonces Jesús respondiendo, dijo: No sabéis lo que pedís. ¿Podéis beber de la copa de que yo tengo que beber; y ser bautizados del bautismo de que yo soy bautizado? Dicen \add ellos\add*: Podemos.
-\v 23 El les dice: A la verdad de mi copa beberéis; y del bautismo de que yo soy bautizado, seréis bautizados; mas sentaros a mi mano derecha, y a mi izquierda, no es mío darlo, sino a los que está aparejado por mi Padre.
+\v 23 Él les dice: A la verdad de mi copa beberéis; y del bautismo de que yo soy bautizado, seréis bautizados; mas sentaros a mi mano derecha, y a mi izquierda, no es mío darlo, sino a los que está aparejado por mi Padre.
 \v 24 ¶ Y como los diez oyeron \add esto\add*, se enojaron de los dos hermanos.
 \v 25 Entonces Jesús llamándolos, dijo: \add Ya\add* sabéis que los príncipes de los Gentiles se enseñorean sobre ellos; y los que son grandes ejercen sobre ellos potestad.
 \v 26 Mas entre vosotros no será así; sino el que entre vosotros quisiere hacerse grande, será vuestro servidor;
@@ -724,7 +724,7 @@
 \v 13 Y les dice: Escrito está: Mi casa, casa de oración será llamada; mas vosotros cueva de ladrones la habéis hecho.
 \v 14 Entonces vinieron a él ciegos y cojos en el templo, y los sanó.
 \v 15 ¶ Mas los príncipes de los sacerdotes y los escribas, viendo las maravillas que hacía, y los muchachos aclamando en el templo, y diciendo: Hosanna al Hijo de David: se enojaron,
-\v 16 Y le dijeron: ¿Oyes lo que estos dicen? Y Jesús les dice: Si: ¿Nunca leísteis: De la boca de los niños, y de los que maman perfeccionaste la alabanza?
+\v 16 Y le dijeron: ¿Oyes lo que estos dicen? Y Jesús les dice: Sí: ¿Nunca leísteis: De la boca de los niños, y de los que maman perfeccionaste la alabanza?
 \v 17 Y dejándolos, se salió fuera de la ciudad a Betania; y posó allí.
 \v 18 ¶ Y por la mañana volviendo a la ciudad, tuvo hambre.
 \v 19 Y viendo una higuera cerca del camino, vino a ella, y no halló nada en ella, sino hojas solamente; y le dijo: Nunca más nazca de ti fruto para siempre. Y luego la higuera se secó.
@@ -798,7 +798,7 @@
 \v 40 De estos dos mandamientos depende toda la ley, y los profetas.
 \v 41 Y estando juntos los Fariseos, Jesús les preguntó,
 \v 42 Diciendo: ¿Qué os parece del Cristo? ¿Cúyo hijo es? Dícenle \add ellos\add*: De David.
-\v 43 El les dice: Pues, ¿cómo David en Espíritu le llama Señor, diciendo:
+\v 43 Él les dice: Pues, ¿cómo David en Espíritu le llama Señor, diciendo:
 \v 44 Dijo el Señor a mi Señor: Asiéntate a mi diestra, entre tanto que pongo tus enemigos por estrado de tus pies?
 \v 45 Pues si David le llama Señor, ¿cómo es su hijo?
 \v 46 Y nadie le podía responder palabra: ni osó alguno desde aquel día preguntarle más.

--- a/USFM/42_MRK_RV1865.usfm
+++ b/USFM/42_MRK_RV1865.usfm
@@ -198,7 +198,7 @@
 \v 36 Mas Jesús luego, en oyendo esta razón que se decía, dijo al príncipe de la sinagoga: No temas: cree solamente.
 \v 37 Y no permitió que alguno viniese tras él, sino Pedro, y Santiago, y Juan hermano de Santiago.
 \v 38 Y vino a casa del príncipe de la sinagoga, y vio el alboroto, y los que lloraban y gemían mucho.
-\v 39 Y entrado, les dice: ¿Por qué os alborotáis, y lloráis: La joven no es muerta, sino que duerme.
+\v 39 Y entrado, les dice: ¿Por qué os alborotáis, y lloráis? La joven no es muerta, sino que duerme.
 \v 40 Y hacían burla de él; mas él, echados fuera todos, toma al padre y a la madre de la joven, y a los que estaban con él, y entra donde estaba la joven echada.
 \v 41 Y tomando la mano de la joven, le dice: Talitha cumi; que quiere decir: Joven, a ti digo, levántate.
 \v 42 Y luego la joven se levantó, y andaba; porque era de doce años: y se espantaron de grande espanto.
@@ -408,7 +408,7 @@
 \v 17 ¶ Y saliendo él para ir su camino, llegóse uno corriendo, e hincando la rodilla delante de él, le preguntó: Maestro bueno, ¿qué haré para poseer la vida eterna?
 \v 18 Y Jesús le dijo: ¿Por qué me dices bueno? Ninguno \add hay\add* bueno, sino uno, Dios.
 \v 19 Sabes los mandamientos: No adulteres: No mates: No hurtes: No digas falso testimonio: No defraudes: Honra a tu padre, y a tu madre.
-\v 20 El entonces respondiendo, le dijo: Maestro, todo esto he guardado desde mi mocedad.
+\v 20 Él entonces respondiendo, le dijo: Maestro, todo esto he guardado desde mi mocedad.
 \v 21 Entonces Jesús mirándole, le amó, y le dijo: Una cosa te falta: vé, todo lo que tienes vende, y dá a los pobres, y tendrás tesoro en el cielo; y ven, toma tu cruz, y sígueme.
 \v 22 Mas él, entristecido por esta palabra, se fue triste, porque tenía muchas posesiones.
 \v 23 Entonces Jesús mirando al derredor, dice a sus discípulos: ¡Cuán dificilmente entrarán en el reino de Dios los que tienen riquezas!
@@ -438,7 +438,7 @@
 \v 47 Y oyendo que era Jesús el Nazareno, comenzó a dar voces, y decir: Jesús, Hijo de David, ten misericordia de mí.
 \v 48 Y muchos le reñían, para que callase; mas él daba mayores voces: Hijo de David, ten misericordia de mí.
 \v 49 Entonces Jesús parándose, mandó llamarle; y llaman al ciego, diciéndole: Ten confianza: levántate, \add que\add* te llama.
-\v 50 El entonces echando a un lado su capa, se levantó, y vino a Jesús.
+\v 50 Él entonces echando a un lado su capa, se levantó, y vino a Jesús.
 \v 51 Y respondiendo Jesús, le dice: ¿Qué quieres que te haga? El ciego le dice: Señor, que vea yo.
 \v 52 Y Jesús le dijo: Vé: tu fe te ha sanado. Y luego vio, y seguía a Jesús en el camino.
 \c 11
@@ -634,7 +634,7 @@
 \c 15
 \v 1 Y luego por la mañana, hecho consejo, los sumos sacerdotes con los ancianos, y con los escribas, y con todo el concilio, trajeron a Jesús atado, y \add le\add* entregaron a Pilato.
 \v 2 Y le preguntó Pilato: ¿Eres tú el Rey de los Judíos? Y respondiendo él, le dijo: Tú \add lo\add* dices.
-\v 3 Y le acusaban los príncipes de los sacerdotes de muchas cosas: mas él no respondió nada.
+\v 3 Y le acusaban los príncipes de los sacerdotes de muchas cosas.
 \v 4 Y le preguntó otra vez Pilato, diciendo: ¿No respondes algo? Mira cuán muchas cosas atestiguan contra ti.
 \v 5 Mas Jesús ni aun con eso respondió, de manera que Pilato se maravillaba.
 \v 6 Empero en \add el día de\add* la fiesta les soltaba un preso, cualquiera que pidiesen.

--- a/USFM/43_LUK_RV1865.usfm
+++ b/USFM/43_LUK_RV1865.usfm
@@ -386,7 +386,7 @@
 \v 18 Mirád pues como oís; porque a cualquiera que tuviere, le será dado; y a cualquiera que no tuviere, aun lo que parece tener le será quitado.
 \v 19 ¶ Entonces vinieron a él su madre y hermanos, y no podían llegar a él por causa de la multitud.
 \v 20 Y le fue dado aviso, diciendo: Tu madre, y tus hermanos están fuera, que quieren verte.
-\v 21 El entonces respondiendo, les dijo: Mi madre y mis hermanos son los que oyen la palabra de Dios, y la hacen.
+\v 21 Él entonces respondiendo, les dijo: Mi madre y mis hermanos son los que oyen la palabra de Dios, y la hacen.
 \v 22 ¶ Y aconteció un día que él entró en una nave con sus discípulos, y les dijo: Pasemos a la otra parte del lago; y se partieron.
 \v 23 Y navegando ellos, se durmió. Y descendió una tempestad de viento en el lago; y se llenaban \add de agua\add*, y peligraban.
 \v 24 Y llegándose a él, le despertaron, diciendo: Maestro, maestro, \add que\add* perecemos. Y despertado él, riñó al viento y a la tempestad del agua, y cesaron; y fue hecha grande bonanza.
@@ -534,7 +534,7 @@
 \v 3 El pan nuestro de cada día dános\add le\add* hoy.
 \v 4 Y perdónanos nuestros pecados, porque también nosotros perdonamos a todos los que nos deben. Y no nos metas en tentación; mas líbranos de mal.
 \v 5 Les dijo también: ¿Quién de vosotros tendrá un amigo, e irá a él a media noche, y le dirá: Amigo préstame tres panes,
-\v 6 Porque un mi amigo ha venido a mí de camino, y no tengo que ponerle delante;
+\v 6 Porque un mi amigo ha venido a mí de camino, y no tengo que ponerle delante?
 \v 7 Y él dentro respondiendo, diga: No me seas molesto: la puerta está ya cerrada, y mis niños están conmigo en la cama: no puedo levantarme, y darte.
 \v 8 Dígoos, que aunque no se levante a darle por ser su amigo, cierto por su importunidad se levantará, y le dará todo lo que habrá menester.
 \v 9 Y yo os digo: Pedíd, y se os dará: buscád, y hallaréis: tocád, y os será abierto.
@@ -695,7 +695,7 @@
 \v 13 Mas cuando haces banquete, llama a los pobres, los mancos, los cojos, los ciegos;
 \v 14 Y serás bienaventurado; porque ellos no te pueden pagar; mas te será pagado en la resurrección de los justos.
 \v 15 ¶ Y oyendo esto uno de los que juntamente estaban sentados a la mesa, le dijo: Bienaventurado el que comerá pan en el reino de los cielos.
-\v 16 ¶ El entonces le dijo: Un hombre hizo una grande cena, y llamó a muchos.
+\v 16 ¶ Él entonces le dijo: Un hombre hizo una grande cena, y llamó a muchos.
 \v 17 Y a la hora de la cena envió a su siervo a decir a los convidados: Veníd, que ya todo está aparejado.
 \v 18 Y comenzaron todos a una a escusarse. El primero le dijo: He comprado un cortijo, y he menester de salir, y verle: te ruego que me tengas por escusado.
 \v 19 Y el otro dijo: He comprado cinco yuntas de bueyes, y voy a probarlos: ruégote que me tengas por escusado.
@@ -746,7 +746,7 @@
 \v 28 Entonces él se enojó, y no quería entrar. El padre entonces saliendo, le rogaba \add que entrase\add*.
 \v 29 Mas él respondiendo, dijo a \add su\add* padre: He aquí, tantos años \add ha que\add* te sirvo, que nunca he traspasado tu mandamiento, y nunca me has dado un cabrito para que haga banquete con mis amigos;
 \v 30 Mas después que vino éste tu hijo, que ha engullido tu hacienda con rameras, le has matado el becerro grueso.
-\v 31 El entonces le dijo: Hijo, tú siempre estás conmigo, y todas mis cosas son tuyas;
+\v 31 Él entonces le dijo: Hijo, tú siempre estás conmigo, y todas mis cosas son tuyas;
 \v 32 Mas hacer banquete y holgar\add nos\add* era menester; porque éste tu hermano muerto era, y revivió: se había perdido, y es hallado.
 \c 16
 \v 1 Y decía también a sus discípulos: Había un hombre rico, el cual tenía un mayordomo; y éste fue acusado delante de él, como disipador de sus bienes.
@@ -967,7 +967,7 @@
 \v 5 ¶ Y a unos que decían del templo, que estaba adornado de hermosas piedras y dones, dijo:
 \v 6 \add De\add* estas cosas que veis, días vendrán, en que no quedará piedra sobre piedra que no sea derribada.
 \v 7 Y le preguntaron, diciendo: Maestro, ¿cuándo será esto? ¿Y qué señal \add habrá\add* cuándo estas cosas hayan de comenzar a ser hechas?
-\v 8 El entonces dijo: Mirád, no seáis engañados; porque vendrán muchos en mi nombre, diciendo: Yo soy \add el Cristo\add*; y el tiempo está cerca: por tanto no vayáis en pos de ellos.
+\v 8 Él entonces dijo: Mirád, no seáis engañados; porque vendrán muchos en mi nombre, diciendo: Yo soy \add el Cristo\add*; y el tiempo está cerca: por tanto no vayáis en pos de ellos.
 \v 9 Empero cuando oyereis de guerras y sediciones, no os espantéis; porque es menester que estas cosas acontezcan primero; mas no luego \add será\add* el fin.
 \v 10 Entonces les dijo: Se levantará nación contra nación, y reino contra reino;
 \v 11 Y habrá grandes terremotos en cada lugar, y hambres, y pestilencias; y habrá prodigios, y grandes señales del cielo.

--- a/USFM/44_JHN_RV1865.usfm
+++ b/USFM/44_JHN_RV1865.usfm
@@ -14,7 +14,7 @@
 \v 5 Y la luz en las tinieblas resplandece; y las tinieblas no la comprendieron.
 \v 6 ¶ Fue un hombre enviado de Dios, el cual se llamaba Juan.
 \v 7 Este vino por testimonio, para que diese testimonio de la Luz, para que por él todos creyesen.
-\v 8 El no era la Luz; mas \add fue enviado\add* para que diese testimonio de la Luz.
+\v 8 Él no era la Luz; mas \add fue enviado\add* para que diese testimonio de la Luz.
 \v 9 \add Aquella Palabra\add* era la Luz verdadera, que alumbra a todo hombre, que viene en este mundo.
 \v 10 En el mundo estaba, y el mundo fue hecho por él, y el mundo no le conoció.
 \v 11 A lo suyo vino; y los suyos no le recibieron.
@@ -211,7 +211,7 @@
 \v 32 Otro es el que da testimonio de mí; y yo sé que el testimonio que él da de mí, es verdadero.
 \v 33 Vosotros enviasteis a Juan, y él dio testimonio a la verdad.
 \v 34 Empero yo no tomo el testimonio de hombre: mas digo estas cosas, para que vosotros seáis salvos.
-\v 35 El era antorcha que ardía, y alumbraba; y vosotros quisisteis regocijaros por un poco en su luz.
+\v 35 Él era antorcha que ardía, y alumbraba; y vosotros quisisteis regocijaros por un poco en su luz.
 \v 36 Mas yo tengo mayor testimonio que \add el\add* de Juan; porque las obras que el Padre me dio que cumpliese, \add es a saber\add*, las mismas obras que yo hago, dan testimonio de mí, que el Padre me haya enviado.
 \v 37 Y el Padre mismo que me envió, él dio testimonio de mí. Vosotros nunca habéis oído su voz, ni habéis visto su parecer.
 \v 38 Ni tenéis su palabra permanente en vosotros; porque al que él envió, a éste vosotros no creéis.
@@ -629,7 +629,7 @@
 \v 22 Entonces los discípulos mirábanse los unos a los otros, dudando de quien hablaba.
 \v 23 Y uno de sus discípulos, al cual Jesús amaba, estaba recostado en el seno de Jesús.
 \v 24 A éste pues hizo señas Simón Pedro, para que preguntase quien era aquel de quien hablaba.
-\v 25 El entonces recostado sobre el pecho de Jesús, le dice: ¿Señor, quién es?
+\v 25 Él entonces recostado sobre el pecho de Jesús, le dice: ¿Señor, quién es?
 \v 26 Respondió Jesús: Aquel es, a quien yo diere el pan mojado. Y mojando el pan, dió\add lo\add* a Júdas Iscariote, \add el hijo\add* de Simón.
 \v 27 Y tras el bocado Satanás entró en él. Entonces Jesús le dice: Lo que haces, házlo más presto.
 \v 28 Empero esto ninguno de los que estaban a la mesa entendió a qué propósito se lo dijo.
@@ -717,7 +717,7 @@
 \v 11 De juicio, por cuanto el príncipe de este mundo \add ya\add* es juzgado.
 \v 12 Aun tengo muchas cosas que deciros, mas ahora no las podéis llevar.
 \v 13 Empero cuando viniere aquel, el Espíritu de verdad, él os guiará a toda verdad; porque no hablará de sí mismo, mas todo lo que oyere hablará; y las cosas que han de venir os hará saber.
-\v 14 El me glorificará, porque tomará de lo mío, y os \add lo\add* hará saber.
+\v 14 Él me glorificará, porque tomará de lo mío, y os \add lo\add* hará saber.
 \v 15 Todo lo que tiene el Padre, mío es: por eso dije que tomará de lo mío, y os \add lo\add* hará saber.
 \v 16 Un poco, y no me veréis; y otra vez un poco, y me veréis; porque yo voy al Padre.
 \v 17 Entonces dijeron \add algunos\add* de sus discípulos unos a otros: ¿Qué es esto que nos dice: Un poco, y no me veréis; y otra vez, un poco, y me veréis; y, porque yo voy al Padre?
@@ -789,7 +789,7 @@
 \v 22 Y como él hubo dicho esto, uno de los ministros que estaba allí, dio una bofetada a Jesús, diciendo: ¿Así respondes al sumo sacerdote?
 \v 23 Respondióle Jesús: Si he hablado mal, da testimonio del mal; mas si bien, ¿por qué me hieres?
 \v 24 Habíale enviado Annás atado a Caifás sumo sacerdote.
-\v 25 Estaba pues Pedro en pie calentándose: y le dijeron: ¿No eres tú también \add uno\add* de sus discípulos? El \add lo\add* negó, y dijo: No soy.
+\v 25 Estaba pues Pedro en pie calentándose: y le dijeron: ¿No eres tú también \add uno\add* de sus discípulos? Él \add lo\add* negó, y dijo: No soy.
 \v 26 Uno de los criados del sumo sacerdote, pariente de aquel a quien Pedro había cortado la oreja, le dice: ¿No te ví yo en el huerto con él?
 \v 27 Y negó Pedro otra vez; y luego el gallo cantó.
 \v 28 ¶ Y llevan a Jesús de Caifás al pretorio; y era de mañana; y ellos no entraron en el pretorio por no ser contaminados, sino poder comer la pascua.

--- a/USFM/45_ACT_RV1865.usfm
+++ b/USFM/45_ACT_RV1865.usfm
@@ -293,7 +293,7 @@
 \v 24 Respondiendo entonces Simón, dijo: Rogád vosotros por mí al Señor, que ninguna cosa de estas, que habéis dicho, venga sobre mí.
 \v 25 ¶ Y ellos habiendo testificado y hablado la palabra de Dios, se volvieron a Jerusalem, y en muchas tierras de los Samaritanos anunciaban el evangelio.
 \v 26 Empero el ángel del Señor habló a Felipe, diciendo: Levántate, y ve hacia el mediodía, al camino que desciende de Jerusalem a Gaza: la cual es desierta.
-\v 27 El entonces se levantó, y fue; y he aquí un Etiope, eunuco, valido de Candaces, reina de los Etiopes, el cual tenía a su cargo todos los tesoros de ella, y había venido a adorar en Jerusalem,
+\v 27 Él entonces se levantó, y fue; y he aquí un Etiope, eunuco, valido de Candaces, reina de los Etiopes, el cual tenía a su cargo todos los tesoros de ella, y había venido a adorar en Jerusalem,
 \v 28 Se volvía, y, sentado en su carro, leía al profeta Isaías.
 \v 29 Y el Espíritu dijo a Felipe: Llégate, y júntate a este carro.
 \v 30 Y acudiendo Felipe, le oyó que leía al profeta Isaías, y dijo: ¿Mas entiendes lo que lees?
@@ -610,7 +610,7 @@
 \v 26 Entonces fue hecho de repente un gran terremoto, de tal manera que los cimientos de la cárcel se movían; y luego todas las puertas se abrieron; y las prisiones de todos se soltaron.
 \v 27 Y despertado el carcelero, como vio abiertas las puertas de la cárcel, sacando la espada se quería matar, pensando que los presos se habían huido.
 \v 28 Mas Pablo clamó a gran voz, diciendo: No te hagas ningún mal: que todos estamos aquí.
-\v 29 El entonces pidiendo una luz, entró dentro, y temblando se derribó a los pies de Pablo y de Silas.
+\v 29 Él entonces pidiendo una luz, entró dentro, y temblando se derribó a los pies de Pablo y de Silas.
 \v 30 Y sacándolos fuera, les dijo: Señores, ¿Qué debo yo hacer para ser salvo?
 \v 31 Y ellos \add le\add* dijeron: Cree en el Señor Jesu Cristo, y serás salvo tú, y tu casa.
 \v 32 Y le hablaron la palabra del Señor, y a todos los que estaban en su casa.
@@ -857,7 +857,7 @@
 \v 15 Ahora pues vosotros con el concilio hacéd saber al tribuno, que le saque mañana a vosotros, como que queréis entender de él alguna cosa más cierta; y nosotros, antes que él llegue, estamos aparejados para matarle.
 \v 16 Entonces el hijo de la hermana de Pablo, oyendo de las asechanzas, vino, y entró en la fortaleza, y dio aviso a Pablo.
 \v 17 Y Pablo llamando a uno de los centuriones, dijo: Lleva a este mancebo al tribuno, porque tiene cierto aviso que darle.
-\v 18 El entonces tomándole, \add le\add* llevó al tribuno, y dijo: El preso Pablo llamándome, me rogó que trajese a ti este mancebo, que tiene algo que hablarte.
+\v 18 Él entonces tomándole, \add le\add* llevó al tribuno, y dijo: El preso Pablo llamándome, me rogó que trajese a ti este mancebo, que tiene algo que hablarte.
 \v 19 Y el tribuno tomándole de la mano, y apartándose aparte \add con él\add*, \add le\add* preguntó: ¿Qué es lo que tienes de que darme aviso?
 \v 20 Y él dijo: Los Judíos han concertado rogarte que mañana saques a Pablo al concilio, como que han de inquirir de él alguna cosa más cierta.
 \v 21 Mas tú no confíes de ellos; porque más de cuarenta varones de ellos le asechan, los cuales han hecho voto, debajo de maldición, de no comer ni beber hasta que le hayan muerto; y ahora están apercibidos esperando tu promesa.

--- a/USFM/46_ROM_RV1865.usfm
+++ b/USFM/46_ROM_RV1865.usfm
@@ -227,7 +227,7 @@
 \v 25 Mas si lo que no vemos esperamos, por paciencia \add lo\add* esperamos.
 \v 26 Y asimismo también el Espíritu a una ayuda nuestra flaqueza; porque no sabemos lo que hemos de pedir como conviene; mas el mismo Espíritu intercede por nosotros con gemidos indecibles.
 \v 27 Mas el que escudriña los corazones, sabe cual \add es\add* el deseo del Espíritu, porque conforme a \add la voluntad de\add* Dios intercede por los santos.
-\v 28 Y sabemos, que todas las cosas obran juntamente para el bien de los que a Dios aman, \add es a saber\add* , a los que conforme a \add su\add* propósito son llamados.
+\v 28 Y sabemos, que todas las cosas obran juntamente para el bien de los que a Dios aman, \add es a saber\add*, a los que conforme a \add su\add* propósito son llamados.
 \v 29 Porque a los que antes conoció, también predestinó \add para que fuesen hechos\add* conformes a la imagen de su Hijo, para que él sea el primogénito entre muchos hermanos.
 \v 30 Y a los que predestinó, a estos también llamó; y a los que llamó, a estos también justificó; y a los que justificó, a estos también glorificó.
 \v 31 ¿Qué, pues, diremos a estas cosas? Si Dios \add es\add* por nosotros, ¿quién \add será\add* contra nosotros?

--- a/USFM/49_GAL_RV1865.usfm
+++ b/USFM/49_GAL_RV1865.usfm
@@ -58,7 +58,7 @@
 \v 2 Esto solo quiero saber de vosotros: ¿Recibisteis el Espíritu por las obras de la ley, o por el oír de la fe?
 \v 3 ¿Tan insensatos sois, \add que\add* habiendo comenzado por el Espíritu, ahora os perfeccionais por la carne?
 \v 4 ¿Tantas cosas habéis padecido en vano? si empero en vano.
-\v 5 El, pues, que os suministra el Espíritu, y obra milagros entre vosotros, ¿\add lo hace\add* por las obras de la ley, o por el oír de la fe?
+\v 5 Él, pues, que os suministra el Espíritu, y obra milagros entre vosotros, ¿\add lo hace\add* por las obras de la ley, o por el oír de la fe?
 \v 6 Así como Abraham creyó a Dios, y le fue contado a justicia.
 \v 7 Sabéd, pues, que los que son de la fe, los tales son hijos de Abraham.
 \v 8 Y viendo antes la Escritura, que Dios por la fe había de justificar a los Gentiles, anunció antes el evangelio a Abraham, \add diciendo\add*: Todas las naciones serán bendecidas en ti.

--- a/USFM/59_HEB_RV1865.usfm
+++ b/USFM/59_HEB_RV1865.usfm
@@ -256,7 +256,7 @@
 \v 28 Por fe celebró la pascua, y el derramamiento de la sangre, para que el que mataba los primogénitos no los tocase.
 \v 29 Por fe pasaron el mar Bermejo como por la \add tierra\add* seca, lo cual probando a \add hacer\add* los Egipcios fueron consumidos.
 \v 30 Por fe cayeron los muros de Jericó con rodearlos siete días.
-\v 31 Por fe Raab la ramera no pereció con los incrédulos, habiendo recibido las espías con paz.
+\v 31 Por fe Raab la ramera no pereció con los incrédulos, habiendo recibido los espías con paz.
 \v 32 ¿Y qué más diré? porque el tiempo me faltará, contando de Gedeón, y \add de\add* Barac, y \add de\add* Samsón, y \add de\add* Jepté; \add de\add* David también, y \add de\add* Samuel, y \add de\add* los profetas:
 \v 33 Los cuales por fe sojuzgaron reinos, obraron justicia, alcanzaron \add el fruto de las\add* promesas, taparon las bocas a leones,
 \v 34 Mataron el ímpetu del fuego, evitaron filo de cuchillo, convalecieron de enfermedades, fueron hechos fuertes en batallas, trastornaron campos de \add enemigos\add* extraños.

--- a/USFM/60_JAS_RV1865.usfm
+++ b/USFM/60_JAS_RV1865.usfm
@@ -24,7 +24,7 @@
 \v 15 Y la concupiscencia después que ha concebido, pare al pecado: y el pecado, siendo cumplido, engendra muerte.
 \v 16 Hermanos míos \add muy\add* amados, no erréis.
 \v 17 Toda buena dádiva, y todo don perfecto es de lo alto, que desciende del Padre de las lumbres, en el cual no hay mudanza, ni sombra de variación.
-\v 18 El de su propia voluntad nos ha engendrado por la palabra de verdad, para que seamos como primicias de sus criaturas.
+\v 18 Él de su propia voluntad nos ha engendrado por la palabra de verdad, para que seamos como primicias de sus criaturas.
 \v 19 Así que, hermanos míos \add muy\add* amados, todo hombre sea pronto para oír, tardío para hablar, tardío para airarse;
 \v 20 Porque la ira del hombre no obra la justicia de Dios.
 \v 21 Por lo cual dejando toda inmundicia, y superfluidad de malicia, recibíd con mansedumbre la palabra injerida en vosotros, la cual puede hacer salvas vuestras almas.

--- a/USFM/67_REV_RV1865.usfm
+++ b/USFM/67_REV_RV1865.usfm
@@ -259,7 +259,7 @@
 \v 8 Y otro ángel le siguió, diciendo: Ya es caída: ya es caída Babilonia, aquella gran ciudad, porque ella ha dado a beber a todas las naciones del vino de la ira de su fornicación.
 \v 9 Y el tercer ángel los siguió, diciendo en alta voz: Si alguno adora a la bestia, y a su imagen, y toma la señal en su frente, o en su mano,
 \v 10 Este tal beberá del vino de la ira de Dios, el cual está echado puro en el cáliz de su ira; y será atormentado con fuego y azufre delante de los santos ángeles, y delante del Cordero.
-\v 11 Y el humo del tormento de ellossube para siempre jamás. Y los que adoran a la bestia, y a su imagen, no tienen reposo día y noche, y \add ni\add* quienquiera que tomare la señal de su nombre.
+\v 11 Y el humo del tormento de ellos sube para siempre jamás. Y los que adoran a la bestia, y a su imagen, no tienen reposo día y noche, y \add ni\add* quienquiera que tomare la señal de su nombre.
 \v 12 Aquí está la paciencia de los santos: aquí \add están\add* los que guardan los mandamientos de Dios, y la fe de Jesús.
 \v 13 Y oí una voz del cielo, que me decía: Escribe: Bienaventurados \add son\add* los muertos, que de aquí adelante mueren en el Señor: Sí, dice el Espíritu, que descansan de sus trabajos, y sus obras los siguen.
 \v 14 Y miré, y he aquí una nube blanca, y sobre la nube \add uno\add* asentado semejante al Hijo del hombre, que tenía en su cabeza una corona de oro, y en su mano una hoz aguzada.


### PR DESCRIPTION
This will be the file to take to print.

2 Reyes 1:3 - Falta signo de interrogación final (1865 PDF) ---> AV
Job 31:31 - incorrect capitalization ---> AV
Ezequiel 46:11 - "parciere" debería ser "pareciere"? ---> AV
Marcos 5:39 - Falta signo de interrogación final (1865 PDF) ---> AV
Lucas 11:5-6 - Falta signo de interrogación final (1865 PDF) ---> AV
Hebreos 11:31 - "las espías" (1569, 1602, 1865 todas las ediciones) ---> AV
Pro 23:35 “despertaré” should be “despertare” —> AV
Mat 21:16 “Si” should be “Sí” —> AV
Mar 15:3 the phrase “mas él no respondió nada.” shouldn't be included (2005 addition) —> AV
Rom 8:28 extra space after “a saber ,” —> AV
Rev 14:11 “ellossube” —> AV
“sujeto" falta tilde - Jueces 4:23 —> AV
“edijos” debería ser “ejidos” - Josué 21:36 —> AV
“el juzgó” falta tilde - Jueces 16:31 —> AV
"un cuatro” debería ser “cuarto” - 1 Samuel 9:8 —> AV
“delCineo” falta espacio (impresa solamente) 1 Samuel 30:29 (Already fixed)
“bebe agua” debería ser “beba agua” 1 Reyes 13:18 —> AV
“despartará” es “despertará” 1 Reyes 14:14 —> AV
“palabra de Jehová fue a el” falta tilde “él” 1 Reyes 17:2 —> AV
“él otro” no lleva acento 1 Reyes 20:35 —> AV
“vuestros” es singular 2 Reyes 17:39 —> AV
“conduto” sería “conducto” actualmente 2 Reyes 18:17 —> AV
“a cerca” tiene espacio 2 Reyes 22:13 —> AV
“siguendo” debería ser “siguiendo” 1 Crónicas 5:25 —> AV
“recebirlos” debería ser “recibirlos” 1 Crónicas 19:5 —> AV
“puediese” debería ser “pudiese” 2 Crónicas 32:14 —> AV
Missing “de” for “hijo Finees” Ezra 8:33 —> AV
“ciduad” debería ser “ciudad” Nehemías 2:3 —> AV
“una fantasma” debería ser “un fantasma” Job 4:16 —> AV
“El quita” y el toma” faltan tildes Job 12:20 —> AV
“él que me traga” tilde innecesario Salmo 57:3 —> AV
“YOJEHOVÁ” falta espacio Jeremías 9:24 ——> AV (fixed in GitHub/Alternate_Versification)
“hablo” missing accent - Genesis 4:8 —> AV
Missing space “pueblosalieron” Exo 16:27 —> AV
“sobre el” missing accent - Leviticus 19:17 —> AV
“pasámos” unnecessary accent - Deut 2:8 —> AV
“dartela” missing accent - Deuteronomy 6:10 —> AV
“el comerá” missing accent - Deuteronomy 28:55 —> AV
“mí” has wrong accent - Jeremiah 15:16 ——> AV
Psalm 12:5 “el” missing tilde —> AV